### PR TITLE
Return primitive values when redacting

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function fastRedact (opts = {}) {
   const compileRestore = restorer({secret, wcLen})
   const strict = 'strict' in opts ? opts.strict : true
 
-  return redactor({secret, wcLen, serialize, strict}, state({
+  return redactor({secret, wcLen, serialize}, state({
     secret,
     censor,
     compileRestore,

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function fastRedact (opts = {}) {
   const compileRestore = restorer({secret, wcLen})
   const strict = 'strict' in opts ? opts.strict : true
 
-  return redactor({secret, wcLen, serialize}, state({
+  return redactor({secret, wcLen, serialize, strict}, state({
     secret,
     censor,
     compileRestore,
@@ -49,6 +49,5 @@ function fastRedact (opts = {}) {
     nestedRedact,
     wildcards,
     wcLen,
-    strict
   }))
 }

--- a/index.js
+++ b/index.js
@@ -38,8 +38,9 @@ function fastRedact (opts = {}) {
   const { wildcards, wcLen, secret } = parse({paths, censor})
 
   const compileRestore = restorer({secret, wcLen})
+  const strict = 'strict' in opts ? opts.strict : true
 
-  return redactor({secret, wcLen, serialize}, state({
+  return redactor({secret, wcLen, serialize, strict}, state({
     secret,
     censor,
     compileRestore,
@@ -47,6 +48,7 @@ function fastRedact (opts = {}) {
     groupRedact,
     nestedRedact,
     wildcards,
-    wcLen
+    wcLen,
+    strict
   }))
 }

--- a/index.js
+++ b/index.js
@@ -48,6 +48,6 @@ function fastRedact (opts = {}) {
     groupRedact,
     nestedRedact,
     wildcards,
-    wcLen,
+    wcLen
   }))
 }

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -4,10 +4,6 @@ const rx = require('./rx')
 
 module.exports = redactor
 
-const throwOnPrimative = `
-
-`
-
 function redactor ({secret, serialize, wcLen, strict}, state) {
   /* eslint-disable-next-line */
   const redact = Function('o', `

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -4,12 +4,15 @@ const rx = require('./rx')
 
 module.exports = redactor
 
-function redactor ({secret, serialize, wcLen}, state) {
+const throwOnPrimative = `
+
+`
+
+function redactor ({secret, serialize, wcLen, strict}, state) {
   /* eslint-disable-next-line */
   const redact = Function('o', `
     if (typeof o !== 'object' || o == null) {
-      if (this.strict) throw Error('fast-redact: primitives cannot be redacted')
-      return o;
+      ${strictImpl(strict)}
     }
     const { censor, secret } = this
     ${redactTmpl(secret)}
@@ -44,7 +47,7 @@ function redactTmpl (secret) {
     const circularDetection = `
       switch (true) {
         ${hops.reverse().map((p) => `
-          case o${delim}${p} === censor: 
+          case o${delim}${p} === censor:
             secret[${escPath}].circle = ${JSON.stringify(p)}
             break
         `).join('\n')}
@@ -86,4 +89,8 @@ function resultTmpl (serialize) {
     this.restore(o)
     return s
   `
+}
+
+function strictImpl (strict) {
+  return strict === true ? `throw Error('fast-redact: primitives cannot be redacted')` : `return o`
 }

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -8,7 +8,7 @@ function redactor ({secret, serialize, wcLen}, state) {
   /* eslint-disable-next-line */
   const redact = Function('o', `
     if (typeof o !== 'object' || o == null) {
-      throw Error('fast-redact: primitives cannot be redacted')
+      return o
     }
     const { censor, secret } = this
     ${redactTmpl(secret)}

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -8,7 +8,8 @@ function redactor ({secret, serialize, wcLen}, state) {
   /* eslint-disable-next-line */
   const redact = Function('o', `
     if (typeof o !== 'object' || o == null) {
-      return o
+      if (this.strict) throw Error('fast-redact: primitives cannot be redacted')
+      return o;
     }
     const { censor, secret } = this
     ${redactTmpl(secret)}

--- a/lib/state.js
+++ b/lib/state.js
@@ -11,9 +11,10 @@ function state (o) {
     groupRedact,
     nestedRedact,
     wildcards,
-    wcLen
+    wcLen,
+    strict
   } = o
-  const builder = [{secret, censor, compileRestore}]
+  const builder = [{secret, censor, compileRestore, strict}]
   builder.push({secret})
   if (serialize !== false) builder.push({serialize})
   if (wcLen > 0) builder.push({groupRedact, nestedRedact, wildcards, wcLen})

--- a/lib/state.js
+++ b/lib/state.js
@@ -12,9 +12,8 @@ function state (o) {
     nestedRedact,
     wildcards,
     wcLen,
-    strict
   } = o
-  const builder = [{secret, censor, compileRestore, strict}]
+  const builder = [{secret, censor, compileRestore}]
   builder.push({secret})
   if (serialize !== false) builder.push({serialize})
   if (wcLen > 0) builder.push({groupRedact, nestedRedact, wildcards, wcLen})

--- a/readme.md
+++ b/readme.md
@@ -155,9 +155,9 @@ console.log(o) // { a: 1, b: 2 }
 ```
 
 #### `strict` – `Boolean` - `[true]`
-The `strict` option, when set to `true`, will cause the redactor function to throw an error when it encounters
-a primitive type. When `strict` is set to `false`, the redactor function will return the primitive value without
-being redacted.
+The `strict` option, when set to `true`, will cause the redactor function to throw if instead 
+of an object it finds a primitive. When `strict` is set to `false`, the redactor function 
+will return the primitive value without being redacted.
 
 ## Approach
 

--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,11 @@ console.log(redact.restore(o) === o) // true
 console.log(o) // { a: 1, b: 2 }
 ```
 
+#### `strict` – `Boolean` - `[true]`
+The `strict` option, when set to `true`, will cause the redactor function to throw an error when it encounters
+a primitive type. When `strict` is set to `false`, the redactor function will return the primitive value without
+being redacted.
+
 ## Approach
 
 In order to achieve lowest cost/highest performance redaction `fast-redact`

--- a/test/index.js
+++ b/test/index.js
@@ -21,8 +21,14 @@ test('returns serializer when passed no paths [serialize: default]', ({end, is})
   end()
 })
 
-test('returns original value when passed non-object', ({end, is, doesNotThrow}) => {
-  const redact = fastRedact({paths: ['a.b.c']})
+test('throws when passed non-object', ({end, throws}) => {
+  const redact = fastRedact({paths: ['a.b.c'], serialize: false})
+  throws(() => redact(1))
+  end()
+})
+
+test('returns original value when passed non-object [strict: false]', ({end, is, doesNotThrow}) => {
+  const redact = fastRedact({paths: ['a.b.c'], strict: false})
   doesNotThrow(() => redact(1))
   const o = redact(1)
   is(o, 1)

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,6 @@ test('returns serializer when passed no paths [serialize: default]', ({end, is})
 })
 
 test('returns original value when passed non-object', ({end, is, doesNotThrow}) => {
-  const censor = 'test'
   const redact = fastRedact({paths: ['a.b.c']})
   doesNotThrow(() => redact(1))
   const o = redact(1)

--- a/test/index.js
+++ b/test/index.js
@@ -21,13 +21,19 @@ test('returns serializer when passed no paths [serialize: default]', ({end, is})
   end()
 })
 
-test('throws when passed non-object', ({end, throws}) => {
-  const redact = fastRedact({paths: ['a.b.c'], serialize: false})
+test('throws when passed non-object using defaults', ({end, throws}) => {
+  const redact = fastRedact({paths: ['a.b.c']})
   throws(() => redact(1))
   end()
 })
 
-test('returns original value when passed non-object [strict: false]', ({end, is, doesNotThrow}) => {
+test('throws when passed non-object using [strict: true]', ({end, throws}) => {
+  const redact = fastRedact({paths: ['a.b.c'], strict: true})
+  throws(() => redact(1))
+  end()
+})
+
+test('returns original value when passed non-object using [strict: false]', ({end, is, doesNotThrow}) => {
   const redact = fastRedact({paths: ['a.b.c'], strict: false})
   doesNotThrow(() => redact(1))
   const o = redact(1)

--- a/test/index.js
+++ b/test/index.js
@@ -21,9 +21,12 @@ test('returns serializer when passed no paths [serialize: default]', ({end, is})
   end()
 })
 
-test('throws when passed non-object', ({end, throws}) => {
-  const redact = fastRedact({paths: ['a.b.c'], serialize: false})
-  throws(() => redact(1))
+test('returns original value when passed non-object', ({end, is, doesNotThrow}) => {
+  const censor = 'test'
+  const redact = fastRedact({paths: ['a.b.c']})
+  doesNotThrow(() => redact(1))
+  const o = redact(1)
+  is(o, 1)
   end()
 })
 


### PR DESCRIPTION
Previous behavior was to throw an error for non-objects. Closes #3 