### PR TITLE
Add check to restorer before mutating original object with value it did not have

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -2,15 +2,15 @@
 const bench = require('fastbench')
 const noir = require('pino-noir')(['a.b.c'])
 const fastRedact = require('..')
-const redactNoSerialize = fastRedact({paths: ['a.b.c'], serialize: false})
-const redactWildNoSerialize = fastRedact({paths: ['a.b.*'], serialize: false})
-const redactIntermediateWildNoSerialize = fastRedact({paths: ['a.*.c'], serialize: false})
-const redact = fastRedact({paths: ['a.b.c']})
+const redactNoSerialize = fastRedact({ paths: ['a.b.c'], serialize: false })
+const redactWildNoSerialize = fastRedact({ paths: ['a.b.*'], serialize: false })
+const redactIntermediateWildNoSerialize = fastRedact({ paths: ['a.*.c'], serialize: false })
+const redact = fastRedact({ paths: ['a.b.c'] })
 const noirWild = require('pino-noir')(['a.b.*'])
-const redactWild = fastRedact({paths: ['a.b.*']})
-const redactIntermediateWild = fastRedact({paths: ['a.*.c']})
-const redactIntermediateWildMatchWildOutcome = fastRedact({paths: ['a.*.c', 'a.*.b', 'a.*.a']})
-const redactStaticMatchWildOutcome = fastRedact({paths: ['a.b.c', 'a.d.a', 'a.d.b', 'a.d.c']})
+const redactWild = fastRedact({ paths: ['a.b.*'] })
+const redactIntermediateWild = fastRedact({ paths: ['a.*.c'] })
+const redactIntermediateWildMatchWildOutcome = fastRedact({ paths: ['a.*.c', 'a.*.b', 'a.*.a'] })
+const redactStaticMatchWildOutcome = fastRedact({ paths: ['a.b.c', 'a.d.a', 'a.d.b', 'a.d.c'] })
 
 const obj = {
   a: {

--- a/example/intermediate-wildcard-array.js
+++ b/example/intermediate-wildcard-array.js
@@ -1,11 +1,11 @@
 'use strict'
 const fastRedact = require('..')
-const redact = fastRedact({paths: ['a[*].c.d']})
+const redact = fastRedact({ paths: ['a[*].c.d'] })
 const obj = {
   a: [
-    {c: {d: 'hide me', e: 'leave me be'}},
-    {c: {d: 'and me', f: 'I want to live'}},
-    {c: {d: 'and also I', g: 'I want to run in a stream'}}
+    { c: { d: 'hide me', e: 'leave me be' } },
+    { c: { d: 'and me', f: 'I want to live' } },
+    { c: { d: 'and also I', g: 'I want to run in a stream' } }
   ]
 }
 console.log(redact(obj))

--- a/example/serialize-false.js
+++ b/example/serialize-false.js
@@ -4,7 +4,7 @@ const redact = fastRedact({
   paths: ['a'],
   serialize: false
 })
-const o = {a: 1, b: 2}
+const o = { a: 1, b: 2 }
 console.log(redact(o) === o)
 console.log(o)
 console.log(redact.restore(o) === o)

--- a/example/serialize-function.js
+++ b/example/serialize-function.js
@@ -1,4 +1,4 @@
 'use strict'
 const fastRedact = require('..')
-const redact = fastRedact({paths: ['a'], serialize: (o) => JSON.stringify(o, 0, 2)})
-console.log(redact({a: 1, b: 2}))
+const redact = fastRedact({ paths: ['a'], serialize: (o) => JSON.stringify(o, 0, 2) })
+console.log(redact({ a: 1, b: 2 }))

--- a/example/top-wildcard-object.js
+++ b/example/top-wildcard-object.js
@@ -1,9 +1,9 @@
 'use strict'
 const fastRedact = require('..')
-const redact = fastRedact({paths: ['*.c.d']})
+const redact = fastRedact({ paths: ['*.c.d'] })
 const obj = {
-  x: {c: {d: 'hide me', e: 'leave me be'}},
-  y: {c: {d: 'and me', f: 'I want to live'}},
-  z: {c: {d: 'and also I', g: 'I want to run in a stream'}}
+  x: { c: { d: 'hide me', e: 'leave me be' } },
+  y: { c: { d: 'and me', f: 'I want to live' } },
+  z: { c: { d: 'and also I', g: 'I want to run in a stream' } }
 }
 console.log(redact(obj))

--- a/index.js
+++ b/index.js
@@ -33,14 +33,14 @@ function fastRedact (opts = {}) {
 
   if (paths.length === 0) return serialize || noop
 
-  validate({paths, serialize, censor})
+  validate({ paths, serialize, censor })
 
-  const { wildcards, wcLen, secret } = parse({paths, censor})
+  const { wildcards, wcLen, secret } = parse({ paths, censor })
 
-  const compileRestore = restorer({secret, wcLen})
+  const compileRestore = restorer({ secret, wcLen })
   const strict = 'strict' in opts ? opts.strict : true
 
-  return redactor({secret, wcLen, serialize, strict}, state({
+  return redactor({ secret, wcLen, serialize, strict }, state({
     secret,
     censor,
     compileRestore,

--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -7,7 +7,7 @@ module.exports = {
   nestedRestore
 }
 
-function groupRestore ({keys, values, target}) {
+function groupRestore ({ keys, values, target }) {
   if (target == null) return
   const length = keys.length
   for (var i = 0; i < length; i++) {
@@ -18,7 +18,7 @@ function groupRestore ({keys, values, target}) {
 
 function groupRedact (o, path, censor) {
   const target = get(o, path)
-  if (target == null) return {keys: null, values: null, target: null, flat: true}
+  if (target == null) return { keys: null, values: null, target: null, flat: true }
   const keys = Object.keys(target)
   const length = keys.length
   const values = new Array(length)
@@ -27,7 +27,7 @@ function groupRedact (o, path, censor) {
     values[i] = target[k]
     target[k] = censor
   }
-  return {keys, values, target, flat: true}
+  return { keys, values, target, flat: true }
 }
 
 function nestedRestore (arr) {
@@ -48,7 +48,7 @@ function nestedRedact (store, o, path, ns, censor) {
     const { value, parent, exists } = specialSet(target, key, ns, censor)
 
     if (exists === true && parent !== null) {
-      store.push({key: ns[ns.length - 1], target: parent, value})
+      store.push({ key: ns[ns.length - 1], target: parent, value })
     }
   }
   return store
@@ -68,7 +68,7 @@ function specialSet (o, k, p, v) {
   var oov
   var exists = true
   ov = n = o[k]
-  if (typeof n !== 'object') return {value: null, parent: null, exists}
+  if (typeof n !== 'object') return { value: null, parent: null, exists }
   while (n != null && ++i < l) {
     k = p[i]
     nv = v
@@ -83,7 +83,7 @@ function specialSet (o, k, p, v) {
     n = n[k]
     if (typeof n !== 'object') break
   }
-  return {value: ov, parent: oov, exists}
+  return { value: ov, parent: oov, exists }
 }
 function get (o, p) {
   var i = -1

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -4,7 +4,7 @@ const rx = require('./rx')
 
 module.exports = parse
 
-function parse ({paths, censor}) {
+function parse ({ paths, censor }) {
   const wildcards = []
   var wcLen = 0
   const secret = paths.reduce(function (o, strPath, ix) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -4,7 +4,7 @@ const rx = require('./rx')
 
 module.exports = parse
 
-function parse ({ paths, censor }) {
+function parse ({ paths }) {
   const wildcards = []
   var wcLen = 0
   const secret = paths.reduce(function (o, strPath, ix) {
@@ -31,7 +31,7 @@ function parse ({ paths, censor }) {
     } else {
       o[strPath] = {
         path: path,
-        val: null,
+        val: undefined,
         precensored: false,
         circle: '',
         escPath: JSON.stringify(strPath),

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -52,7 +52,6 @@ function redactTmpl (secret) {
     return `
       if (${existence}) {
         const val = o${delim}${path}
-        secret[${escPath}].censored = true
         if (val === censor) {
           secret[${escPath}].precensored = true
         } else {

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -52,6 +52,7 @@ function redactTmpl (secret) {
     return `
       if (${existence}) {
         const val = o${delim}${path}
+        secret[${escPath}].censored = true
         if (val === censor) {
           secret[${escPath}].precensored = true
         } else {

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -4,7 +4,7 @@ const rx = require('./rx')
 
 module.exports = redactor
 
-function redactor ({secret, serialize, wcLen, strict}, state) {
+function redactor ({ secret, serialize, wcLen, strict }, state) {
   /* eslint-disable-next-line */
   const redact = Function('o', `
     if (typeof o !== 'object' || o == null) {

--- a/lib/restorer.js
+++ b/lib/restorer.js
@@ -4,14 +4,14 @@ const { groupRestore, nestedRestore } = require('./modifiers')
 
 module.exports = restorer
 
-function restorer ({secret, wcLen}) {
+function restorer ({ secret, wcLen }) {
   return function compileRestore () {
     if (this.restore) return
     const paths = Object.keys(secret)
       .filter((path) => secret[path].precensored === false)
     const resetters = resetTmpl(secret, paths)
     const hasWildcards = wcLen > 0
-    const state = hasWildcards ? {secret, groupRestore, nestedRestore} : {secret}
+    const state = hasWildcards ? { secret, groupRestore, nestedRestore } : { secret }
     /* eslint-disable-next-line */
     this.restore = Function(
       'o',

--- a/lib/restorer.js
+++ b/lib/restorer.js
@@ -20,6 +20,15 @@ function restorer ({ secret, wcLen }) {
   }
 }
 
+/**
+ * Mutates the original object to be censored by restoring its original values
+ * prior to censoring.
+ *
+ * @param {object} secret Compiled object describing which target fields should
+ * be censored and the field states.
+ * @param {string[]} paths The list of paths to censor as provided at
+ * construction time.
+ */
 function resetTmpl (secret, paths) {
   return paths.map((path) => {
     const { circle, escPath, leadingBracket } = secret[path]
@@ -29,8 +38,10 @@ function resetTmpl (secret, paths) {
       : `o${delim}${path} = secret[${escPath}].val`
     const clear = `secret[${escPath}].val = null`
     return `
-      try { ${reset} } catch (e) {}
-      ${clear}
+      if (secret[${escPath}].censored === true) {
+        try { ${reset} } catch (e) {}
+        ${clear}
+      }
     `
   }).join('')
 }

--- a/lib/restorer.js
+++ b/lib/restorer.js
@@ -28,6 +28,9 @@ function restorer ({ secret, wcLen }) {
  * be censored and the field states.
  * @param {string[]} paths The list of paths to censor as provided at
  * construction time.
+ *
+ * @returns {string} String of JavaScript to be used by `Function()`. The
+ * string compiles to the function that does the work in the description.
  */
 function resetTmpl (secret, paths) {
   return paths.map((path) => {

--- a/lib/restorer.js
+++ b/lib/restorer.js
@@ -27,7 +27,7 @@ function restorer ({ secret, wcLen }) {
  * @param {object} secret Compiled object describing which target fields should
  * be censored and the field states.
  * @param {string[]} paths The list of paths to censor as provided at
- * construction time.
+ * initialization time.
  *
  * @returns {string} String of JavaScript to be used by `Function()`. The
  * string compiles to the function that does the work in the description.
@@ -41,7 +41,7 @@ function resetTmpl (secret, paths) {
       : `o${delim}${path} = secret[${escPath}].val`
     const clear = `secret[${escPath}].val = null`
     return `
-      if (secret[${escPath}].censored === true) {
+      if (secret[${escPath}].val !== undefined) {
         try { ${reset} } catch (e) {}
         ${clear}
       }

--- a/lib/state.js
+++ b/lib/state.js
@@ -11,11 +11,11 @@ function state (o) {
     groupRedact,
     nestedRedact,
     wildcards,
-    wcLen,
+    wcLen
   } = o
-  const builder = [{secret, censor, compileRestore}]
-  builder.push({secret})
-  if (serialize !== false) builder.push({serialize})
-  if (wcLen > 0) builder.push({groupRedact, nestedRedact, wildcards, wcLen})
+  const builder = [{ secret, censor, compileRestore }]
+  builder.push({ secret })
+  if (serialize !== false) builder.push({ serialize })
+  if (wcLen > 0) builder.push({ groupRedact, nestedRedact, wildcards, wcLen })
   return Object.assign(...builder)
 }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -11,7 +11,7 @@ function validator (opts = {}) {
     ERR_INVALID_PATH = (s) => `fast-redact – Invalid path (${s})`
   } = opts
 
-  return function validate ({paths, serialize, censor}) {
+  return function validate ({ paths, serialize, censor }) {
     if (typeof censor === 'function') {
       throw Error(ERR_CENSOR_MUST_NOT_BE_FUNCTION())
     }
@@ -21,7 +21,7 @@ function validator (opts = {}) {
       }
       try {
         if (/〇/.test(s)) throw Error()
-        const proxy = new Proxy({}, {get: () => proxy, set: () => { throw Error() }})
+        const proxy = new Proxy({}, { get: () => proxy, set: () => { throw Error() } })
         const expr = (s[0] === '[' ? '' : '.') + s.replace(/^\*/, '〇').replace(/\.\*/g, '.〇').replace(/\[\*\]/g, '[〇]')
         if (/\n|\r|;/.test(expr)) throw Error()
         if (/\/\*/.test(expr)) throw Error()
@@ -31,8 +31,8 @@ function validator (opts = {}) {
             o${expr}
             if ([o${expr}].length !== 1) throw Error()
           })()
-        `, createContext({o: proxy, 〇: null}), {
-          codeGeneration: {strings: false, wasm: false}
+        `, createContext({ o: proxy, 〇: null }), {
+          codeGeneration: { strings: false, wasm: false }
         })
       } catch (e) {
         throw Error(ERR_INVALID_PATH(s))

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tap test",
+    "pretest": "standard index.js 'lib/*.js' 'example/*.js' benchmark/index.js test/index.js | snazzy",
     "cov": "tap --cov test",
     "cov-ui": "tap --coverage-report=html test",
     "ci": "tap --cov --100 test",
@@ -26,12 +27,13 @@
   "devDependencies": {
     "fastbench": "^1.0.1",
     "pino-noir": "^2.2.1",
+    "snazzy": "^8.0.0",
+    "standard": "^12.0.1",
     "tap": "^12.0.1"
   },
   "engines": {
     "node": ">=6"
   },
-  "dependencies": {},
   "directories": {
     "example": "example",
     "lib": "lib",

--- a/test/index.js
+++ b/test/index.js
@@ -828,16 +828,16 @@ test('(leading brackets) static + wildcards reuse', ({ end, is }) => {
 test('correctly restores original object when a path does not match object', ({ end, is }) => {
   const redact = fastRedact({ paths: ['foo.bar'], strict: false })
   const o = {}
-  redact({ foo: o })
+  is(redact({ foo: o }), '{"foo":{}}')
   is(o.hasOwnProperty('bar'), false)
   end()
 })
 
 test('correctly restores original object when a matchin path has value of `undefined`', ({ end, is }) => {
   const redact = fastRedact({ paths: ['foo.bar'], strict: false })
-  const o = { foo: { bar: undefined } }
-  redact({ foo: o })
-  is(o.foo.hasOwnProperty('bar'), true)
-  is(o.foo.bar, undefined)
+  const o = { bar: undefined  }
+  is(redact({ foo: o }), '{"foo":{}}')
+  is(o.hasOwnProperty('bar'), true)
+  is(o.bar, undefined)
   end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -826,7 +826,7 @@ test('(leading brackets) static + wildcards reuse', ({ end, is }) => {
 })
 
 test('correctly restores original object with nested null paths', ({ end, ok }) => {
-  const redact = fastRedact({ paths: ['foo.bar'] }, { strict: false })
+  const redact = fastRedact({ paths: ['foo.bar'], strict: false })
   const o = {}
   redact({ foo: o })
   ok(o.hasOwnProperty('bar') === false)

--- a/test/index.js
+++ b/test/index.js
@@ -5,8 +5,8 @@ const fastRedact = require('..')
 
 const censor = '[REDACTED]'
 
-test('returns no-op when passed no paths [serialize: false]', ({end, doesNotThrow}) => {
-  const redact = fastRedact({paths: [], serialize: false})
+test('returns no-op when passed no paths [serialize: false]', ({ end, doesNotThrow }) => {
+  const redact = fastRedact({ paths: [], serialize: false })
   doesNotThrow(() => redact({}))
   doesNotThrow(() => {
     const o = redact({})
@@ -15,179 +15,179 @@ test('returns no-op when passed no paths [serialize: false]', ({end, doesNotThro
   end()
 })
 
-test('returns serializer when passed no paths [serialize: default]', ({end, is}) => {
-  is(fastRedact({paths: []}), JSON.stringify)
+test('returns serializer when passed no paths [serialize: default]', ({ end, is }) => {
+  is(fastRedact({ paths: [] }), JSON.stringify)
   is(fastRedact(), JSON.stringify)
   end()
 })
 
-test('throws when passed non-object using defaults', ({end, throws}) => {
-  const redact = fastRedact({paths: ['a.b.c']})
+test('throws when passed non-object using defaults', ({ end, throws }) => {
+  const redact = fastRedact({ paths: ['a.b.c'] })
   throws(() => redact(1))
   end()
 })
 
-test('throws when passed non-object using [strict: true]', ({end, throws}) => {
-  const redact = fastRedact({paths: ['a.b.c'], strict: true})
+test('throws when passed non-object using [strict: true]', ({ end, throws }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], strict: true })
   throws(() => redact(1))
   end()
 })
 
-test('returns original value when passed non-object using [strict: false]', ({end, is, doesNotThrow}) => {
-  const redact = fastRedact({paths: ['a.b.c'], strict: false})
+test('returns original value when passed non-object using [strict: false]', ({ end, is, doesNotThrow }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], strict: false })
   doesNotThrow(() => redact(1))
   const o = redact(1)
   is(o, 1)
   end()
 })
 
-test('throws if a path is not a string', ({end, is, throws}) => {
+test('throws if a path is not a string', ({ end, is, throws }) => {
   throws((e) => {
-    fastRedact({paths: [1]})
+    fastRedact({ paths: [1] })
   }, Error('fast-redact - Paths must be strings'))
   throws((e) => {
-    fastRedact({paths: [null]})
+    fastRedact({ paths: [null] })
   }, Error('fast-redact - Paths must be strings'))
   throws((e) => {
-    fastRedact({paths: [undefined]})
+    fastRedact({ paths: [undefined] })
   }, Error('fast-redact - Paths must be strings'))
   throws((e) => {
-    fastRedact({paths: [{}]})
+    fastRedact({ paths: [{}] })
   }, Error('fast-redact - Paths must be strings'))
   end()
 })
 
-test('throws when passed illegal paths', ({end, is, throws}) => {
+test('throws when passed illegal paths', ({ end, is, throws }) => {
   const err = (s) => Error(`fast-redact – Invalid path (${s})`)
   throws((e) => {
-    fastRedact({paths: ['@']})
+    fastRedact({ paths: ['@'] })
   }, err('@'))
   throws((e) => {
-    fastRedact({paths: ['0']})
+    fastRedact({ paths: ['0'] })
   }, err('0'))
   throws((e) => {
-    fastRedact({paths: ['〇']})
+    fastRedact({ paths: ['〇'] })
   }, err('〇'))
   throws((e) => {
-    fastRedact({paths: ['a.1.c']})
+    fastRedact({ paths: ['a.1.c'] })
   }, err('a.1.c'))
   throws((e) => {
-    fastRedact({paths: ['a..c']})
+    fastRedact({ paths: ['a..c'] })
   }, err('a..c'))
   throws((e) => {
-    fastRedact({paths: ['1..c']})
+    fastRedact({ paths: ['1..c'] })
   }, err('1..c'))
   throws((e) => {
-    fastRedact({paths: ['a = b']})
+    fastRedact({ paths: ['a = b'] })
   }, err('a = b'))
   throws((e) => {
-    fastRedact({paths: ['a(b)']})
+    fastRedact({ paths: ['a(b)'] })
   }, err('a(b)'))
   throws((e) => {
-    fastRedact({paths: ['//a.b.c']})
+    fastRedact({ paths: ['//a.b.c'] })
   }, err('//a.b.c'))
   throws((e) => {
-    fastRedact({paths: ['\\a.b.c']})
+    fastRedact({ paths: ['\\a.b.c'] })
   }, err('\\a.b.c'))
   throws((e) => {
-    fastRedact({paths: ['a.#.c']})
+    fastRedact({ paths: ['a.#.c'] })
   }, err('a.#.c'))
   throws((e) => {
-    fastRedact({paths: ['~~a.b.c']})
+    fastRedact({ paths: ['~~a.b.c'] })
   }, err('~~a.b.c'))
   throws((e) => {
-    fastRedact({paths: ['^a.b.c']})
+    fastRedact({ paths: ['^a.b.c'] })
   }, err('^a.b.c'))
   throws((e) => {
-    fastRedact({paths: ['a + b']})
+    fastRedact({ paths: ['a + b'] })
   }, err('a + b'))
   throws((e) => {
-    fastRedact({paths: ['return a + b']})
+    fastRedact({ paths: ['return a + b'] })
   }, err('return a + b'))
   throws((e) => {
-    fastRedact({paths: ['a / b']})
+    fastRedact({ paths: ['a / b'] })
   }, err('a / b'))
   throws((e) => {
-    fastRedact({paths: ['a * b']})
+    fastRedact({ paths: ['a * b'] })
   }, err('a * b'))
   throws((e) => {
-    fastRedact({paths: ['a - b']})
+    fastRedact({ paths: ['a - b'] })
   }, err('a - b'))
   throws((e) => {
-    fastRedact({paths: ['a ** b']})
+    fastRedact({ paths: ['a ** b'] })
   }, err('a ** b'))
   throws((e) => {
-    fastRedact({paths: ['a % b']})
+    fastRedact({ paths: ['a % b'] })
   }, err('a % b'))
   throws((e) => {
-    fastRedact({paths: ['a.b*.c']})
+    fastRedact({ paths: ['a.b*.c'] })
   }, err('a.b*.c'))
   throws((e) => {
-    fastRedact({paths: ['a;global.foo = "bar"']})
+    fastRedact({ paths: ['a;global.foo = "bar"'] })
   }, err('a;global.foo = "bar"'))
   throws((e) => {
-    fastRedact({paths: ['a;while(1){}']})
+    fastRedact({ paths: ['a;while(1){}'] })
   }, err('a;while(1){}'))
   throws((e) => {
-    fastRedact({paths: ['a//']})
+    fastRedact({ paths: ['a//'] })
   }, err('a//'))
   throws((e) => {
-    fastRedact({paths: ['a/*foo*/']})
+    fastRedact({ paths: ['a/*foo*/'] })
   }, err('a/*foo*/'))
   throws((e) => {
-    fastRedact({paths: ['a,o.b']})
+    fastRedact({ paths: ['a,o.b'] })
   }, err('a,o.b'))
   throws((e) => {
-    fastRedact({paths: ['a = o.b']})
+    fastRedact({ paths: ['a = o.b'] })
   }, err('a = o.b'))
   throws((e) => {
-    fastRedact({paths: ['a\n']})
+    fastRedact({ paths: ['a\n'] })
   }, err('a\n'))
   throws((e) => {
-    fastRedact({paths: ['a\r']})
+    fastRedact({ paths: ['a\r'] })
   }, err('a\r'))
   end()
 })
 
-test('throws if more than one wildcard in a path', ({end, throws}) => {
+test('throws if more than one wildcard in a path', ({ end, throws }) => {
   throws(() => {
-    fastRedact({paths: ['a.*.x.*'], serialize: false})
+    fastRedact({ paths: ['a.*.x.*'], serialize: false })
   }, Error('fast-redact – Only one wildcard per path is supported'))
   end()
 })
 
-test('throws if a custom serializer is used and remove is true', ({end, throws}) => {
+test('throws if a custom serializer is used and remove is true', ({ end, throws }) => {
   throws(() => {
-    fastRedact({paths: ['a'], serialize: (o) => o, remove: true})
+    fastRedact({ paths: ['a'], serialize: (o) => o, remove: true })
   }, Error('fast-redact – remove option may only be set when serializer is JSON.stringify'))
   end()
 })
 
-test('throws if serialize is false and remove is true', ({end, throws}) => {
+test('throws if serialize is false and remove is true', ({ end, throws }) => {
   throws(() => {
-    fastRedact({paths: ['a'], serialize: false, remove: true})
+    fastRedact({ paths: ['a'], serialize: false, remove: true })
   }, Error('fast-redact – remove option may only be set when serializer is JSON.stringify'))
   end()
 })
 
-test('masks according to supplied censor', ({end, is}) => {
+test('masks according to supplied censor', ({ end, is }) => {
   const censor = 'test'
-  const redact = fastRedact({paths: ['a'], censor, serialize: false})
-  is(redact({a: 'a'}).a, censor)
+  const redact = fastRedact({ paths: ['a'], censor, serialize: false })
+  is(redact({ a: 'a' }).a, censor)
   end()
 })
 
-test('redact.restore function is available when serialize is false', ({end, is}) => {
+test('redact.restore function is available when serialize is false', ({ end, is }) => {
   const censor = 'test'
-  const redact = fastRedact({paths: ['a'], censor, serialize: false})
+  const redact = fastRedact({ paths: ['a'], censor, serialize: false })
   is(typeof redact.restore, 'function')
   end()
 })
 
-test('redact.restore function places original values back in place', ({end, is}) => {
+test('redact.restore function places original values back in place', ({ end, is }) => {
   const censor = 'test'
-  const redact = fastRedact({paths: ['a'], censor, serialize: false})
-  const o = {a: 'a'}
+  const redact = fastRedact({ paths: ['a'], censor, serialize: false })
+  const o = { a: 'a' }
   redact(o)
   is(o.a, censor)
   redact.restore(o)
@@ -195,160 +195,160 @@ test('redact.restore function places original values back in place', ({end, is})
   end()
 })
 
-test('serializes with JSON.stringify by default', ({end, is}) => {
-  const redact = fastRedact({paths: ['a']})
-  const o = {a: 'a'}
+test('serializes with JSON.stringify by default', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a'] })
+  const o = { a: 'a' }
   is(redact(o), `{"a":"${censor}"}`)
   is(o.a, 'a')
   end()
 })
 
-test('removes during serialization instead of redacting when remove option is true', ({end, is}) => {
-  const redact = fastRedact({paths: ['a'], remove: true})
-  const o = {a: 'a', b: 'b'}
+test('removes during serialization instead of redacting when remove option is true', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a'], remove: true })
+  const o = { a: 'a', b: 'b' }
   is(redact(o), `{"b":"b"}`)
   is(o.a, 'a')
   end()
 })
 
-test('serializes with JSON.stringify if serialize is true', ({end, is}) => {
-  const redact = fastRedact({paths: ['a'], serialize: true})
-  const o = {a: 'a'}
+test('serializes with JSON.stringify if serialize is true', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a'], serialize: true })
+  const o = { a: 'a' }
   is(redact(o), `{"a":"${censor}"}`)
   is(o.a, 'a')
   end()
 })
 
-test('serializes with JSON.stringify if serialize is not a function', ({end, is}) => {
-  const redact = fastRedact({paths: ['a'], serialize: {}})
-  const o = {a: 'a'}
+test('serializes with JSON.stringify if serialize is not a function', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a'], serialize: {} })
+  const o = { a: 'a' }
   is(redact(o), `{"a":"${censor}"}`)
   is(o.a, 'a')
   end()
 })
 
-test('serializes with custom serializer if supplied', ({end, is}) => {
-  const redact = fastRedact({paths: ['a'], serialize: (o) => JSON.stringify(o, 0, 2)})
-  const o = {a: 'a'}
+test('serializes with custom serializer if supplied', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a'], serialize: (o) => JSON.stringify(o, 0, 2) })
+  const o = { a: 'a' }
   is(redact(o), `{\n  "a": "${censor}"\n}`)
   is(o.a, 'a')
   end()
 })
 
-test('redacts parent keys', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.b.c'], serialize: false})
-  const result = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('redacts parent keys', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], serialize: false })
+  const result = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a.b.c, censor)
   end()
 })
 
-test('supports paths with array indexes', ({end, same}) => {
-  const redact = fastRedact({paths: ['insideArray.like[3].this'], serialize: false})
-  same(redact({insideArray: {like: ['a', 'b', 'c', {this: {foo: 'meow'}}]}}), {insideArray: {like: ['a', 'b', 'c', {this: censor}]}})
+test('supports paths with array indexes', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['insideArray.like[3].this'], serialize: false })
+  same(redact({ insideArray: { like: ['a', 'b', 'c', { this: { foo: 'meow' } }] } }), { insideArray: { like: ['a', 'b', 'c', { this: censor }] } })
   end()
 })
 
-test('censor may be any type, except function which will throw', ({end, same, throws}) => {
-  const redactToString = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: 'censor', serialize: false})
-  const redactToUndefined = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: undefined, serialize: false})
+test('censor may be any type, except function which will throw', ({ end, same, throws }) => {
+  const redactToString = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: 'censor', serialize: false })
+  const redactToUndefined = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: undefined, serialize: false })
   const sym = Symbol('sym')
-  const redactToSymbol = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: sym, serialize: false})
-  const redactToNumber = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: 0, serialize: false})
-  const redactToBoolean = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: false, serialize: false})
-  const redactToNull = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: null, serialize: false})
-  const redactToObject = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: {redacted: true}, serialize: false})
-  const redactToArray = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: ['redacted'], serialize: false})
-  const redactToBuffer = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: Buffer.from('redacted'), serialize: false})
-  const redactToError = fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: Error('redacted'), serialize: false})
-  same(redactToString({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: 'censor', d: {x: 'censor', y: 'censor'}}}})
-  same(redactToUndefined({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: undefined, d: {x: undefined, y: undefined}}}})
-  same(redactToSymbol({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: sym, d: {x: sym, y: sym}}}})
-  same(redactToNumber({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: 0, d: {x: 0, y: 0}}}})
-  same(redactToBoolean({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: false, d: {x: false, y: false}}}})
-  same(redactToNull({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: null, d: {x: null, y: null}}}})
-  same(redactToObject({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: {redacted: true}, d: {x: {redacted: true}, y: {redacted: true}}}}})
-  same(redactToArray({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: ['redacted'], d: {x: ['redacted'], y: ['redacted']}}}})
-  same(redactToBuffer({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: Buffer.from('redacted'), d: {x: Buffer.from('redacted'), y: Buffer.from('redacted')}}}})
-  same(redactToError({a: {b: {c: 's', d: {x: 's', y: 's'}}}}), {a: {b: {c: Error('redacted'), d: {x: Error('redacted'), y: Error('redacted')}}}})
-  throws(() => fastRedact({paths: ['a.b.c', 'a.b.d.*'], censor: () => {}, serialize: false}))
+  const redactToSymbol = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: sym, serialize: false })
+  const redactToNumber = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: 0, serialize: false })
+  const redactToBoolean = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: false, serialize: false })
+  const redactToNull = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: null, serialize: false })
+  const redactToObject = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: { redacted: true }, serialize: false })
+  const redactToArray = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: ['redacted'], serialize: false })
+  const redactToBuffer = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: Buffer.from('redacted'), serialize: false })
+  const redactToError = fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: Error('redacted'), serialize: false })
+  same(redactToString({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: 'censor', d: { x: 'censor', y: 'censor' } } } })
+  same(redactToUndefined({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: undefined, d: { x: undefined, y: undefined } } } })
+  same(redactToSymbol({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: sym, d: { x: sym, y: sym } } } })
+  same(redactToNumber({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: 0, d: { x: 0, y: 0 } } } })
+  same(redactToBoolean({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: false, d: { x: false, y: false } } } })
+  same(redactToNull({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: null, d: { x: null, y: null } } } })
+  same(redactToObject({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: { redacted: true }, d: { x: { redacted: true }, y: { redacted: true } } } } })
+  same(redactToArray({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: ['redacted'], d: { x: ['redacted'], y: ['redacted'] } } } })
+  same(redactToBuffer({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: Buffer.from('redacted'), d: { x: Buffer.from('redacted'), y: Buffer.from('redacted') } } } })
+  same(redactToError({ a: { b: { c: 's', d: { x: 's', y: 's' } } } }), { a: { b: { c: Error('redacted'), d: { x: Error('redacted'), y: Error('redacted') } } } })
+  throws(() => fastRedact({ paths: ['a.b.c', 'a.b.d.*'], censor: () => {}, serialize: false }))
   end()
 })
 
-test('supports multiple paths from the same root', ({end, same}) => {
-  const redact = fastRedact({paths: ['deep.bar.shoe', 'deep.baz.shoe', 'deep.foo', 'deep.not.there.sooo', 'deep.fum.shoe'], serialize: false})
-  same(redact({deep: {bar: 'hmm', baz: {shoe: {k: 1}}, foo: {}, fum: {shoe: 'moo'}}}), {deep: {bar: 'hmm', baz: {shoe: censor}, foo: censor, fum: {shoe: censor}}})
+test('supports multiple paths from the same root', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['deep.bar.shoe', 'deep.baz.shoe', 'deep.foo', 'deep.not.there.sooo', 'deep.fum.shoe'], serialize: false })
+  same(redact({ deep: { bar: 'hmm', baz: { shoe: { k: 1 } }, foo: {}, fum: { shoe: 'moo' } } }), { deep: { bar: 'hmm', baz: { shoe: censor }, foo: censor, fum: { shoe: censor } } })
   end()
 })
 
-test('supports strings in bracket notation paths (single quote)', ({end, is}) => {
-  const redact = fastRedact({paths: [`a['@#!='].c`], serialize: false})
-  const result = redact({a: {'@#!=': {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('supports strings in bracket notation paths (single quote)', ({ end, is }) => {
+  const redact = fastRedact({ paths: [`a['@#!='].c`], serialize: false })
+  const result = redact({ a: { '@#!=': { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a['@#!='].c, censor)
   end()
 })
 
-test('supports strings in bracket notation paths (double quote)', ({end, is}) => {
-  const redact = fastRedact({paths: [`a["@#!="].c`], serialize: false})
-  const result = redact({a: {'@#!=': {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('supports strings in bracket notation paths (double quote)', ({ end, is }) => {
+  const redact = fastRedact({ paths: [`a["@#!="].c`], serialize: false })
+  const result = redact({ a: { '@#!=': { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a['@#!='].c, censor)
   end()
 })
 
-test('supports strings in bracket notation paths (backtick quote)', ({end, is}) => {
-  const redact = fastRedact({paths: ['a[`@#!=`].c'], serialize: false})
-  const result = redact({a: {'@#!=': {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('supports strings in bracket notation paths (backtick quote)', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a[`@#!=`].c'], serialize: false })
+  const result = redact({ a: { '@#!=': { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a['@#!='].c, censor)
   end()
 })
 
-test('allows * within a bracket notation string', ({end, is}) => {
-  const redact = fastRedact({paths: ['a["*"].c'], serialize: false})
-  const result = redact({a: {'*': {c: 's', x: 1}}})
+test('allows * within a bracket notation string', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a["*"].c'], serialize: false })
+  const result = redact({ a: { '*': { c: 's', x: 1 } } })
   is(result.a['*'].c, censor)
   is(result.a['*'].x, 1)
   end()
 })
 
-test('redacts parent keys – restore', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.b.c'], serialize: false})
-  const result = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('redacts parent keys – restore', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], serialize: false })
+  const result = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a.b.c, censor)
   redact.restore(result)
   is(result.a.b.c, 's')
   end()
 })
 
-test('handles null proto objects', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.b.c'], serialize: false})
-  const result = redact({__proto__: null, a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('handles null proto objects', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], serialize: false })
+  const result = redact({ __proto__: null, a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a.b.c, censor)
   end()
 })
 
-test('handles null proto objects – restore', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.b.c'], serialize: false})
-  const result = redact({__proto__: null, a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('handles null proto objects – restore', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], serialize: false })
+  const result = redact({ __proto__: null, a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a.b.c, censor)
   redact.restore(result, 's')
   is(result.a.b.c, 's')
   end()
 })
 
-test('handles paths that do not match object structure', ({end, same}) => {
-  const redact = fastRedact({paths: ['x.y.z'], serialize: false})
-  same(redact({a: {b: {c: 's'}}}), {a: {b: {c: 's'}}})
+test('handles paths that do not match object structure', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['x.y.z'], serialize: false })
+  same(redact({ a: { b: { c: 's' } } }), { a: { b: { c: 's' } } })
   end()
 })
 
-test('ignores missing paths in object', ({end, same}) => {
-  const redact = fastRedact({paths: ['a.b.c', 'a.z.d', 'a.b.z'], serialize: false})
-  same(redact({a: {b: {c: 's'}}}), {a: {b: {c: censor}}})
+test('ignores missing paths in object', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['a.b.c', 'a.z.d', 'a.b.z'], serialize: false })
+  same(redact({ a: { b: { c: 's' } } }), { a: { b: { c: censor } } })
   end()
 })
 
-test('ignores missing paths in object – restore', ({end, doesNotThrow}) => {
-  const redact = fastRedact({paths: ['a.b.c', 'a.z.d', 'a.b.z'], serialize: false})
-  const o = {a: {b: {c: 's'}}}
+test('ignores missing paths in object – restore', ({ end, doesNotThrow }) => {
+  const redact = fastRedact({ paths: ['a.b.c', 'a.z.d', 'a.b.z'], serialize: false })
+  const o = { a: { b: { c: 's' } } }
   redact(o)
   doesNotThrow(() => {
     redact.restore(o)
@@ -357,32 +357,32 @@ test('ignores missing paths in object – restore', ({end, doesNotThrow}) => {
   end()
 })
 
-test('gracefully handles primitives that match intermediate keys in paths', ({end, same}) => {
-  const redact = fastRedact({paths: ['a.b.c', 'a.b.c.d'], serialize: false})
-  same(redact({a: {b: null}}), {a: {b: null}})
-  same(redact({a: {b: 's'}}), {a: {b: 's'}})
-  same(redact({a: {b: 1}}), {a: {b: 1}})
-  same(redact({a: {b: undefined}}), {a: {b: undefined}})
-  same(redact({a: {b: true}}), {a: {b: true}})
+test('gracefully handles primitives that match intermediate keys in paths', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['a.b.c', 'a.b.c.d'], serialize: false })
+  same(redact({ a: { b: null } }), { a: { b: null } })
+  same(redact({ a: { b: 's' } }), { a: { b: 's' } })
+  same(redact({ a: { b: 1 } }), { a: { b: 1 } })
+  same(redact({ a: { b: undefined } }), { a: { b: undefined } })
+  same(redact({ a: { b: true } }), { a: { b: true } })
   const sym = Symbol('sym')
-  same(redact({a: {b: sym}}), {a: {b: sym}})
+  same(redact({ a: { b: sym } }), { a: { b: sym } })
   end()
 })
 
-test('handles circulars', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['bar.baz.baz'], serialize: false})
-  const bar = {b: 2}
-  const o = {a: 1, bar}
+test('handles circulars', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['bar.baz.baz'], serialize: false })
+  const bar = { b: 2 }
+  const o = { a: 1, bar }
   bar.baz = bar
   o.bar.baz = o.bar
-  same(redact(o), {a: 1, bar: {b: 2, baz: censor}})
+  same(redact(o), { a: 1, bar: { b: 2, baz: censor } })
   end()
 })
 
-test('handles circulars – restore', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['bar.baz.baz'], serialize: false})
-  const bar = {b: 2}
-  const o = {a: 1, bar}
+test('handles circulars – restore', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['bar.baz.baz'], serialize: false })
+  const bar = { b: 2 }
+  const o = { a: 1, bar }
   bar.baz = bar
   o.bar.baz = o.bar
   is(o.bar.baz, bar)
@@ -393,10 +393,10 @@ test('handles circulars – restore', ({end, is, same}) => {
   end()
 })
 
-test('handles circulars and cross references – restore', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['bar.baz.baz', 'cf.bar'], serialize: false})
-  const bar = {b: 2}
-  const o = {a: 1, bar, cf: {bar}}
+test('handles circulars and cross references – restore', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['bar.baz.baz', 'cf.bar'], serialize: false })
+  const bar = { b: 2 }
+  const o = { a: 1, bar, cf: { bar } }
   bar.baz = bar
   o.bar.baz = o.bar
   is(o.bar.baz, bar)
@@ -410,75 +410,75 @@ test('handles circulars and cross references – restore', ({end, is, same}) =>
   end()
 })
 
-test('ultimate wildcards – shallow', ({end, same}) => {
-  const redact = fastRedact({paths: ['test.*'], serialize: false})
-  same(redact({test: {baz: 1, bar: 'private'}}), {test: {baz: censor, bar: censor}})
+test('ultimate wildcards – shallow', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['test.*'], serialize: false })
+  same(redact({ test: { baz: 1, bar: 'private' } }), { test: { baz: censor, bar: censor } })
   end()
 })
 
-test('ultimate wildcards – deep', ({end, same}) => {
-  const redact = fastRedact({paths: ['deep.bar.baz.ding.*'], serialize: false})
-  same(redact({deep: {a: 1, bar: {b: 2, baz: {c: 3, ding: {d: 4, e: 5, f: 'six'}}}}}), {deep: {a: 1, bar: {b: 2, baz: {c: 3, ding: {d: censor, e: censor, f: censor}}}}})
+test('ultimate wildcards – deep', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['deep.bar.baz.ding.*'], serialize: false })
+  same(redact({ deep: { a: 1, bar: { b: 2, baz: { c: 3, ding: { d: 4, e: 5, f: 'six' } } } } }), { deep: { a: 1, bar: { b: 2, baz: { c: 3, ding: { d: censor, e: censor, f: censor } } } } })
   end()
 })
 
-test('ultimate wildcards - array – shallow', ({end, same}) => {
-  const redact = fastRedact({paths: ['array[*]'], serialize: false})
-  same(redact({array: ['a', 'b', 'c', 'd']}), {array: [censor, censor, censor, censor]})
+test('ultimate wildcards - array – shallow', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['array[*]'], serialize: false })
+  same(redact({ array: ['a', 'b', 'c', 'd'] }), { array: [censor, censor, censor, censor] })
   end()
 })
 
-test('ultimate wildcards – array – deep', ({end, same}) => {
-  const redact = fastRedact({paths: ['deepArray.down.here[*]'], serialize: false})
-  same(redact({deepArray: {down: {here: ['a', 'b', 'c']}}}), {deepArray: {down: {here: [censor, censor, censor]}}})
+test('ultimate wildcards – array – deep', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['deepArray.down.here[*]'], serialize: false })
+  same(redact({ deepArray: { down: { here: ['a', 'b', 'c'] } } }), { deepArray: { down: { here: [censor, censor, censor] } } })
   end()
 })
 
-test('ultimate wildcards – array – single index', ({end, same}) => {
-  const redact = fastRedact({paths: ['insideArray.like[3].this.*'], serialize: false})
-  same(redact({insideArray: {like: ['a', 'b', 'c', {this: {foo: 'meow'}}]}}), {insideArray: {like: ['a', 'b', 'c', {this: {foo: censor}}]}})
+test('ultimate wildcards – array – single index', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['insideArray.like[3].this.*'], serialize: false })
+  same(redact({ insideArray: { like: ['a', 'b', 'c', { this: { foo: 'meow' } }] } }), { insideArray: { like: ['a', 'b', 'c', { this: { foo: censor } }] } })
   end()
 })
 
-test('ultimate wildcards - handles null proto objects', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.b.c'], serialize: false})
-  const result = redact({__proto__: null, a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('ultimate wildcards - handles null proto objects', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], serialize: false })
+  const result = redact({ __proto__: null, a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a.b.c, censor)
   end()
 })
 
-test('ultimate wildcards - handles paths that do not match object structure', ({end, same}) => {
-  const redact = fastRedact({paths: ['x.y.z'], serialize: false})
-  same(redact({a: {b: {c: 's'}}}), {a: {b: {c: 's'}}})
+test('ultimate wildcards - handles paths that do not match object structure', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['x.y.z'], serialize: false })
+  same(redact({ a: { b: { c: 's' } } }), { a: { b: { c: 's' } } })
   end()
 })
 
-test('ultimate wildcards - gracefully handles primitives that match intermediate keys in paths', ({end, same}) => {
-  const redact = fastRedact({paths: ['a.b.c', 'a.b.c.d'], serialize: false})
-  same(redact({a: {b: null}}), {a: {b: null}})
-  same(redact({a: {b: 's'}}), {a: {b: 's'}})
-  same(redact({a: {b: 1}}), {a: {b: 1}})
-  same(redact({a: {b: undefined}}), {a: {b: undefined}})
-  same(redact({a: {b: true}}), {a: {b: true}})
+test('ultimate wildcards - gracefully handles primitives that match intermediate keys in paths', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['a.b.c', 'a.b.c.d'], serialize: false })
+  same(redact({ a: { b: null } }), { a: { b: null } })
+  same(redact({ a: { b: 's' } }), { a: { b: 's' } })
+  same(redact({ a: { b: 1 } }), { a: { b: 1 } })
+  same(redact({ a: { b: undefined } }), { a: { b: undefined } })
+  same(redact({ a: { b: true } }), { a: { b: true } })
   const sym = Symbol('sym')
-  same(redact({a: {b: sym}}), {a: {b: sym}})
+  same(redact({ a: { b: sym } }), { a: { b: sym } })
   end()
 })
 
-test('ultimate wildcards – handles circulars', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['bar.baz.*'], serialize: false})
-  const bar = {b: 2}
-  const o = {a: 1, bar}
+test('ultimate wildcards – handles circulars', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['bar.baz.*'], serialize: false })
+  const bar = { b: 2 }
+  const o = { a: 1, bar }
   bar.baz = bar
   o.bar.baz = o.bar
-  same(redact(o), {a: 1, bar: {b: censor, baz: censor}})
+  same(redact(o), { a: 1, bar: { b: censor, baz: censor } })
   end()
 })
 
-test('ultimate wildcards – handles circulars – restore', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['bar.baz.*'], serialize: false})
-  const bar = {b: 2}
-  const o = {a: 1, bar}
+test('ultimate wildcards – handles circulars – restore', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['bar.baz.*'], serialize: false })
+  const bar = { b: 2 }
+  const o = { a: 1, bar }
   bar.baz = bar
   o.bar.baz = o.bar
   is(o.bar.baz, bar)
@@ -489,10 +489,10 @@ test('ultimate wildcards – handles circulars – restore', ({end, is, same}) 
   end()
 })
 
-test('ultimate wildcards – handles circulars and cross references – restore', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['bar.baz.*', 'cf.*'], serialize: false})
-  const bar = {b: 2}
-  const o = {a: 1, bar, cf: {bar}}
+test('ultimate wildcards – handles circulars and cross references – restore', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['bar.baz.*', 'cf.*'], serialize: false })
+  const bar = { b: 2 }
+  const o = { a: 1, bar, cf: { bar } }
   bar.baz = bar
   o.bar.baz = o.bar
   is(o.bar.baz, bar)
@@ -506,9 +506,9 @@ test('ultimate wildcards – handles circulars and cross references – restore
   end()
 })
 
-test('static + wildcards', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.b.c', 'a.d.*', 'a.b.z.*'], serialize: false})
-  const result = redact({a: {b: {c: 's', z: {x: 's', y: 's'}}, d: {a: 's', b: 's', c: 's'}}})
+test('static + wildcards', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.b.c', 'a.d.*', 'a.b.z.*'], serialize: false })
+  const result = redact({ a: { b: { c: 's', z: { x: 's', y: 's' } }, d: { a: 's', b: 's', c: 's' } } })
 
   is(result.a.b.c, censor)
   is(result.a.d.a, censor)
@@ -519,9 +519,9 @@ test('static + wildcards', ({end, is}) => {
   end()
 })
 
-test('static + wildcards reuse', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.b.c', 'a.d.*'], serialize: false})
-  const result = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('static + wildcards reuse', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.b.c', 'a.d.*'], serialize: false })
+  const result = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
 
   is(result.a.b.c, censor)
   is(result.a.d.a, censor)
@@ -530,7 +530,7 @@ test('static + wildcards reuse', ({end, is}) => {
 
   redact.restore(result)
 
-  const result2 = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+  const result2 = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result2.a.b.c, censor)
   is(result2.a.d.a, censor)
   is(result2.a.d.b, censor)
@@ -540,9 +540,9 @@ test('static + wildcards reuse', ({end, is}) => {
   end()
 })
 
-test('parent wildcard – first position', ({end, is}) => {
-  const redact = fastRedact({paths: ['*.c'], serialize: false})
-  const result = redact({b: {c: 's'}, d: {a: 's', b: 's', c: 's'}})
+test('parent wildcard – first position', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['*.c'], serialize: false })
+  const result = redact({ b: { c: 's' }, d: { a: 's', b: 's', c: 's' } })
   is(result.b.c, censor)
   is(result.d.a, 's')
   is(result.d.b, 's')
@@ -550,9 +550,9 @@ test('parent wildcard – first position', ({end, is}) => {
   end()
 })
 
-test('parent wildcard – one following key', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.*.c'], serialize: false})
-  const result = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('parent wildcard – one following key', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.*.c'], serialize: false })
+  const result = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a.b.c, censor)
   is(result.a.d.a, 's')
   is(result.a.d.b, 's')
@@ -560,9 +560,9 @@ test('parent wildcard – one following key', ({end, is}) => {
   end()
 })
 
-test('restore parent wildcard  – one following key', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.*.c'], serialize: false})
-  const result = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('restore parent wildcard  – one following key', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.*.c'], serialize: false })
+  const result = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   redact.restore(result)
   is(result.a.b.c, 's')
   is(result.a.d.a, 's')
@@ -571,14 +571,14 @@ test('restore parent wildcard  – one following key', ({end, is}) => {
   end()
 })
 
-test('parent wildcard – one following key – reuse', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.*.c'], serialize: false})
-  const result = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('parent wildcard – one following key – reuse', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.*.c'], serialize: false })
+  const result = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a.b.c, censor)
   is(result.a.d.a, 's')
   is(result.a.d.b, 's')
   is(result.a.d.c, censor)
-  const result2 = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+  const result2 = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result2.a.b.c, censor)
   is(result2.a.d.a, 's')
   is(result2.a.d.b, 's')
@@ -587,9 +587,9 @@ test('parent wildcard – one following key – reuse', ({end, is}) => {
   end()
 })
 
-test('parent wildcard – two following keys', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.*.x.c'], serialize: false})
-  const result = redact({a: {b: {x: {c: 's'}}, d: {x: {a: 's', b: 's', c: 's'}}}})
+test('parent wildcard – two following keys', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.*.x.c'], serialize: false })
+  const result = redact({ a: { b: { x: { c: 's' } }, d: { x: { a: 's', b: 's', c: 's' } } } })
   is(result.a.b.x.c, censor)
   is(result.a.d.x.a, 's')
   is(result.a.d.x.b, 's')
@@ -597,15 +597,15 @@ test('parent wildcard – two following keys', ({end, is}) => {
   end()
 })
 
-test('parent wildcard  – two following keys – reuse', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.*.x.c'], serialize: false})
-  const result = redact({a: {b: {x: {c: 's'}}, d: {x: {a: 's', b: 's', c: 's'}}}})
+test('parent wildcard  – two following keys – reuse', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.*.x.c'], serialize: false })
+  const result = redact({ a: { b: { x: { c: 's' } }, d: { x: { a: 's', b: 's', c: 's' } } } })
   is(result.a.b.x.c, censor)
   is(result.a.d.x.a, 's')
   is(result.a.d.x.b, 's')
   is(result.a.d.x.c, censor)
   redact.restore(result)
-  const result2 = redact({a: {b: {x: {c: 's'}}, d: {x: {a: 's', b: 's', c: 's'}}}})
+  const result2 = redact({ a: { b: { x: { c: 's' } }, d: { x: { a: 's', b: 's', c: 's' } } } })
   is(result2.a.b.x.c, censor)
   is(result2.a.d.x.a, 's')
   is(result2.a.d.x.b, 's')
@@ -613,9 +613,9 @@ test('parent wildcard  – two following keys – reuse', ({end, is}) => {
   end()
 })
 
-test('restore parent wildcard  – two following keys', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.*.x.c'], serialize: false})
-  const result = redact({a: {b: {x: {c: 's'}}, d: {x: {a: 's', b: 's', c: 's'}}}})
+test('restore parent wildcard  – two following keys', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.*.x.c'], serialize: false })
+  const result = redact({ a: { b: { x: { c: 's' } }, d: { x: { a: 's', b: 's', c: 's' } } } })
   redact.restore(result)
   is(result.a.b.x.c, 's')
   is(result.a.d.x.a, 's')
@@ -624,9 +624,9 @@ test('restore parent wildcard  – two following keys', ({end, is}) => {
   end()
 })
 
-test('parent wildcard - array', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.b[*].x'], serialize: false})
-  const result = redact({a: {b: [{x: 1}, {a: 2}], d: {a: 's', b: 's', c: 's'}}})
+test('parent wildcard - array', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.b[*].x'], serialize: false })
+  const result = redact({ a: { b: [{ x: 1 }, { a: 2 }], d: { a: 's', b: 's', c: 's' } } })
   is(result.a.b[0].x, censor)
   is(result.a.b[1].a, 2)
   is(result.a.d.a, 's')
@@ -634,51 +634,51 @@ test('parent wildcard - array', ({end, is}) => {
   end()
 })
 
-test('parent wildcards – array – single index', ({end, same}) => {
-  const redact = fastRedact({paths: ['insideArray.like[3].*.foo'], serialize: false})
-  same(redact({insideArray: {like: ['a', 'b', 'c', {this: {foo: 'meow'}}]}}), {insideArray: {like: ['a', 'b', 'c', {this: {foo: censor}}]}})
+test('parent wildcards – array – single index', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['insideArray.like[3].*.foo'], serialize: false })
+  same(redact({ insideArray: { like: ['a', 'b', 'c', { this: { foo: 'meow' } }] } }), { insideArray: { like: ['a', 'b', 'c', { this: { foo: censor } }] } })
   end()
 })
 
-test('parent wildcards - handles null proto objects', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.*.c'], serialize: false})
-  const result = redact({__proto__: null, a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('parent wildcards - handles null proto objects', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.*.c'], serialize: false })
+  const result = redact({ __proto__: null, a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result.a.b.c, censor)
   end()
 })
 
-test('parent wildcards - handles paths that do not match object structure', ({end, same}) => {
-  const redact = fastRedact({paths: ['a.*.y.z'], serialize: false})
-  same(redact({a: {b: {c: 's'}}}), {a: {b: {c: 's'}}})
+test('parent wildcards - handles paths that do not match object structure', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['a.*.y.z'], serialize: false })
+  same(redact({ a: { b: { c: 's' } } }), { a: { b: { c: 's' } } })
   end()
 })
 
-test('parent wildcards - gracefully handles primitives that match intermediate keys in paths', ({end, same}) => {
-  const redact = fastRedact({paths: ['a.*.c'], serialize: false})
-  same(redact({a: {b: null}}), {a: {b: null}})
-  same(redact({a: {b: 's'}}), {a: {b: 's'}})
-  same(redact({a: {b: 1}}), {a: {b: 1}})
-  same(redact({a: {b: undefined}}), {a: {b: undefined}})
-  same(redact({a: {b: true}}), {a: {b: true}})
+test('parent wildcards - gracefully handles primitives that match intermediate keys in paths', ({ end, same }) => {
+  const redact = fastRedact({ paths: ['a.*.c'], serialize: false })
+  same(redact({ a: { b: null } }), { a: { b: null } })
+  same(redact({ a: { b: 's' } }), { a: { b: 's' } })
+  same(redact({ a: { b: 1 } }), { a: { b: 1 } })
+  same(redact({ a: { b: undefined } }), { a: { b: undefined } })
+  same(redact({ a: { b: true } }), { a: { b: true } })
   const sym = Symbol('sym')
-  same(redact({a: {b: sym}}), {a: {b: sym}})
+  same(redact({ a: { b: sym } }), { a: { b: sym } })
   end()
 })
 
-test('parent wildcards – handles circulars', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['x.*.baz'], serialize: false})
-  const bar = {b: 2}
-  const o = {x: {a: 1, bar}}
+test('parent wildcards – handles circulars', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['x.*.baz'], serialize: false })
+  const bar = { b: 2 }
+  const o = { x: { a: 1, bar } }
   bar.baz = bar
   o.x.bar.baz = o.x.bar
-  same(redact(o), {x: {a: 1, bar: {b: 2, baz: censor}}})
+  same(redact(o), { x: { a: 1, bar: { b: 2, baz: censor } } })
   end()
 })
 
-test('parent wildcards – handles circulars – restore', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['x.*.baz'], serialize: false})
-  const bar = {b: 2}
-  const o = {x: {a: 1, bar}}
+test('parent wildcards – handles circulars – restore', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['x.*.baz'], serialize: false })
+  const bar = { b: 2 }
+  const o = { x: { a: 1, bar } }
   bar.baz = bar
   o.x.bar.baz = o.x.bar
   is(o.x.bar.baz, bar)
@@ -690,10 +690,10 @@ test('parent wildcards – handles circulars – restore', ({end, is, same}) =>
   end()
 })
 
-test('parent wildcards – handles circulars and cross references – restore', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['x.*.baz', 'x.*.cf.bar'], serialize: false})
-  const bar = {b: 2}
-  const o = {x: {a: 1, bar, y: {cf: {bar}}}}
+test('parent wildcards – handles circulars and cross references – restore', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['x.*.baz', 'x.*.cf.bar'], serialize: false })
+  const bar = { b: 2 }
+  const o = { x: { a: 1, bar, y: { cf: { bar } } } }
   bar.baz = bar
   o.x.bar.baz = o.x.bar
   is(o.x.bar.baz, bar)
@@ -707,66 +707,66 @@ test('parent wildcards – handles circulars and cross references – restore',
   end()
 })
 
-test('parent wildcards – handles missing paths', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['z.*.baz']})
-  const o = {a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}}
+test('parent wildcards – handles missing paths', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['z.*.baz'] })
+  const o = { a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } }
   is(redact(o), JSON.stringify(o))
   end()
 })
 
-test('ultimate wildcards – handles missing paths', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['z.*']})
-  const o = {a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}}
+test('ultimate wildcards – handles missing paths', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['z.*'] })
+  const o = { a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } }
   is(redact(o), JSON.stringify(o))
   end()
 })
 
-test('parent wildcards – removes during serialization instead of redacting when remove option is true', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.*.c'], remove: true})
-  const o = {a: {b: {c: 'c'}, x: {c: 1}}}
+test('parent wildcards – removes during serialization instead of redacting when remove option is true', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.*.c'], remove: true })
+  const o = { a: { b: { c: 'c' }, x: { c: 1 } } }
   is(redact(o), `{"a":{"b":{},"x":{}}}`)
   end()
 })
 
-test('ultimate wildcards – removes during serialization instead of redacting when remove option is true', ({end, is}) => {
-  const redact = fastRedact({paths: ['a.b.*'], remove: true})
-  const o = {a: {b: {c: 'c'}, x: {c: 1}}}
+test('ultimate wildcards – removes during serialization instead of redacting when remove option is true', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['a.b.*'], remove: true })
+  const o = { a: { b: { c: 'c' }, x: { c: 1 } } }
   is(redact(o), `{"a":{"b":{},"x":{"c":1}}}`)
   end()
 })
 
-test('supports leading bracket notation', ({end, is}) => {
-  const redact = fastRedact({paths: ['["a"].b.c']})
-  const o = {a: {b: {c: 'd'}}}
+test('supports leading bracket notation', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['["a"].b.c'] })
+  const o = { a: { b: { c: 'd' } } }
   is(redact(o), `{"a":{"b":{"c":"${censor}"}}}`)
   end()
 })
 
-test('supports leading bracket notation containing non-legal keyword characters', ({end, is}) => {
-  const redact = fastRedact({paths: ['["a-x"].b.c']})
-  const o = {'a-x': {b: {c: 'd'}}}
+test('supports leading bracket notation containing non-legal keyword characters', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['["a-x"].b.c'] })
+  const o = { 'a-x': { b: { c: 'd' } } }
   is(redact(o), `{"a-x":{"b":{"c":"${censor}"}}}`)
   end()
 })
 
-test('supports single leading bracket', ({end, is}) => {
+test('supports single leading bracket', ({ end, is }) => {
   const censor = 'test'
-  const redact = fastRedact({paths: ['["a"]'], censor, serialize: false})
-  is(redact({a: 'a'}).a, censor)
+  const redact = fastRedact({ paths: ['["a"]'], censor, serialize: false })
+  is(redact({ a: 'a' }).a, censor)
   end()
 })
 
-test('supports single leading bracket containing non-legal keyword characters', ({end, is}) => {
+test('supports single leading bracket containing non-legal keyword characters', ({ end, is }) => {
   const censor = 'test'
-  const redact = fastRedact({paths: ['["a-x"]'], censor, serialize: false})
-  is(redact({'a-x': 'a'})['a-x'], censor)
+  const redact = fastRedact({ paths: ['["a-x"]'], censor, serialize: false })
+  is(redact({ 'a-x': 'a' })['a-x'], censor)
   end()
 })
 
-test('(leading brackets) ultimate wildcards – handles circulars and cross references – restore', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['bar.baz.*', 'cf.*'], serialize: false})
-  const bar = {b: 2}
-  const o = {a: 1, bar, cf: {bar}}
+test('(leading brackets) ultimate wildcards – handles circulars and cross references – restore', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['bar.baz.*', 'cf.*'], serialize: false })
+  const bar = { b: 2 }
+  const o = { a: 1, bar, cf: { bar } }
   bar.baz = bar
   o.bar.baz = o.bar
   is(o.bar.baz, bar)
@@ -780,10 +780,10 @@ test('(leading brackets) ultimate wildcards – handles circulars and cross refe
   end()
 })
 
-test('(leading brackets) parent wildcards – handles circulars and cross references – restore', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['["x"].*.baz', '["x"].*.cf.bar'], serialize: false})
-  const bar = {b: 2}
-  const o = {x: {a: 1, bar, y: {cf: {bar}}}}
+test('(leading brackets) parent wildcards – handles circulars and cross references – restore', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['["x"].*.baz', '["x"].*.cf.bar'], serialize: false })
+  const bar = { b: 2 }
+  const o = { x: { a: 1, bar, y: { cf: { bar } } } }
   bar.baz = bar
   o.x.bar.baz = o.x.bar
   is(o.x.bar.baz, bar)
@@ -797,16 +797,16 @@ test('(leading brackets) parent wildcards – handles circulars and cross refere
   end()
 })
 
-test('(leading brackets) ultimate wildcards – handles missing paths', ({end, is, same}) => {
-  const redact = fastRedact({paths: ['["z"].*']})
-  const o = {a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}}
+test('(leading brackets) ultimate wildcards – handles missing paths', ({ end, is, same }) => {
+  const redact = fastRedact({ paths: ['["z"].*'] })
+  const o = { a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } }
   is(redact(o), JSON.stringify(o))
   end()
 })
 
-test('(leading brackets) static + wildcards reuse', ({end, is}) => {
-  const redact = fastRedact({paths: ['["a"].b.c', '["a"].d.*'], serialize: false})
-  const result = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+test('(leading brackets) static + wildcards reuse', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['["a"].b.c', '["a"].d.*'], serialize: false })
+  const result = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
 
   is(result.a.b.c, censor)
   is(result.a.d.a, censor)
@@ -815,12 +815,20 @@ test('(leading brackets) static + wildcards reuse', ({end, is}) => {
 
   redact.restore(result)
 
-  const result2 = redact({a: {b: {c: 's'}, d: {a: 's', b: 's', c: 's'}}})
+  const result2 = redact({ a: { b: { c: 's' }, d: { a: 's', b: 's', c: 's' } } })
   is(result2.a.b.c, censor)
   is(result2.a.d.a, censor)
   is(result2.a.d.b, censor)
   is(result2.a.d.c, censor)
 
   redact.restore(result2)
+  end()
+})
+
+test('correctly restores original object with nested null paths', ({ end, ok }) => {
+  const redact = fastRedact({ paths: ['foo.bar'] }, { strict: false })
+  const o = {}
+  redact({ foo: o })
+  ok(o.hasOwnProperty('bar') === false)
   end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -825,10 +825,19 @@ test('(leading brackets) static + wildcards reuse', ({ end, is }) => {
   end()
 })
 
-test('correctly restores original object with nested null paths', ({ end, ok }) => {
+test('correctly restores original object when a path does not match object', ({ end, is }) => {
   const redact = fastRedact({ paths: ['foo.bar'], strict: false })
   const o = {}
   redact({ foo: o })
-  ok(o.hasOwnProperty('bar') === false)
+  is(o.hasOwnProperty('bar'), false)
+  end()
+})
+
+test('correctly restores original object when a matchin path has value of `undefined`', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['foo.bar'], strict: false })
+  const o = { foo: { bar: undefined } }
+  redact({ foo: o })
+  is(o.foo.hasOwnProperty('bar'), true)
+  is(o.foo.bar, undefined)
   end()
 })


### PR DESCRIPTION
this is a continuation of #6 - but a new PR was the easiest way to get around add commits to a forked branch PR (@jsumners I've now invited you as collaborator)

every piece of state we add to the `secret` object _will_ slow things down, so this iteration removes the `censored` flag because we actually already know whether it's been censored or not by whether the `val` has changed (unless it was set to `null` but more on this coming). The `null` value comes from initialisation of the secret object in `parse.js`, however I've changed it's init value to `undefined`. This being a non-JSON value it can safely be used to mean "uninitialized". 

I also added another test  to show that undefined values in this context are handled correctly. 

Whether we use `censored` or check that secret val is undefined, the behaviour is the same: you cannot censor `undefined` values, instead the output will result in the key being stripped. 

Side note, no matter whether `val` is initialized to `null` or `undefined`, or whether we use a `censor` flag you can also not currently redact `null` either, it will leak through. So that might be a separate bug to address - or at least document as expected behaviour. 

cc @mcollina @jsumners