### PR TITLE
Fix for TypeError when redact called with leading wildcard and null property

### DIFF
--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -65,7 +65,7 @@ function specialSet (o, k, p, v, f) {
   var n
   var nv
   var ov
-  var oov
+  var oov = null
   var exists = true
   ov = n = o[k]
   if (typeof n !== 'object') return { value: null, parent: null, exists }

--- a/test/index.js
+++ b/test/index.js
@@ -894,3 +894,11 @@ test('handles objects with and then without target paths', ({ end, is }) => {
   is('test' in o2, false)
   end()
 })
+
+test('handles leading wildcards and null values', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['*.test'] })
+  const o = { prop: null }
+  is(redact(o), '{"prop":null}')
+  is(o.prop, null)
+  end()
+})


### PR DESCRIPTION
This change set includes a test which illustrates the problem and a suggested fix.

To recap:

Problem is that:   path such as `['*.password']` gives a type error when redacting an object with a null property, `{foo: null}`.

Reason: a variable was missing an initial value in its declaration