### PR TITLE
Change false "strict" mode to return strings as JSON instead of raw strings

### DIFF
--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -88,5 +88,5 @@ function resultTmpl (serialize) {
 }
 
 function strictImpl (strict) {
-  return strict === true ? `throw Error('fast-redact: primitives cannot be redacted')` : `return o`
+  return strict === true ? `throw Error('fast-redact: primitives cannot be redacted')` : `return typeof o === 'string' ? JSON.stringify(o) : o`
 }

--- a/readme.md
+++ b/readme.md
@@ -157,7 +157,8 @@ console.log(o) // { a: 1, b: 2 }
 #### `strict` – `Boolean` - `[true]`
 The `strict` option, when set to `true`, will cause the redactor function to throw if instead 
 of an object it finds a primitive. When `strict` is set to `false`, the redactor function 
-will return the primitive value without being redacted.
+will return the primitive value without being redacted and if the primitive is of type "string",
+the primitive value is returned as JSON (i.e. within double quotes and escaped per JSON rules).
 
 ## Approach
 

--- a/test/index.js
+++ b/test/index.js
@@ -28,17 +28,49 @@ test('throws when passed non-object using defaults', ({ end, throws }) => {
   end()
 })
 
-test('throws when passed non-object using [strict: true]', ({ end, throws }) => {
+test('throws when passed non-object number using [strict: true]', ({ end, throws }) => {
   const redact = fastRedact({ paths: ['a.b.c'], strict: true })
   throws(() => redact(1))
   end()
 })
 
-test('returns original value when passed non-object using [strict: false]', ({ end, is, doesNotThrow }) => {
+test('returns original value when passed non-object boolean using [strict: false]', ({ end, is, doesNotThrow }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], strict: false })
+  doesNotThrow(() => redact(true))
+  const o = redact(true)
+  is(o, true)
+  end()
+})
+
+test('returns original value when passed non-object null using [strict: false]', ({ end, is, doesNotThrow }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], strict: false })
+  doesNotThrow(() => redact(null))
+  const o = redact(null)
+  is(o, null)
+  end()
+})
+
+test('returns original value when passed non-object undefined using [strict: false]', ({ end, is, doesNotThrow }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], strict: false })
+  doesNotThrow(() => redact())
+  const o = redact()
+  is(o, undefined)
+  end()
+})
+
+test('returns original value quoted when passed non-object string using [strict: false]', ({ end, is, doesNotThrow }) => {
   const redact = fastRedact({ paths: ['a.b.c'], strict: false })
   doesNotThrow(() => redact(1))
-  const o = redact(1)
-  is(o, 1)
+  const o = redact('A')
+  is(o, '"A"')
+  end()
+})
+
+test('returns original value quoted when passed non-object string using [strict: false]', ({ end, is, doesNotThrow }) => {
+  const redact = fastRedact({ paths: ['a.b.c'], strict: false })
+  doesNotThrow(() => redact(1))
+  const o = redact('A')
+  is(o, '"A"')
   end()
 })
 


### PR DESCRIPTION
This PR stems from discussion in https://github.com/pinojs/pino/pull/599.

When the `strict` option is used with `false` as a value,
```
redact(primitive)
```
returns back the primitive.   When the primitive is a string, this can be a problem when the caller is expecting redact to provide JSON string back.  This confusion can lead to JSON injection attacks.

The fix is to have redact test the type of the primitive and if it's a string, to return JSON.stringify(x).

Individual test cases have been written for each type of primitive (except for Symbol, I'm not sure how that should be handled) and the readme has been updated.
