### PR TITLE
feat: pass path to censor function

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -4,7 +4,7 @@ const noir = require('pino-noir')(['a.b.c'])
 const fastRedact = require('..')
 
 const censorFn = (v) => v + '.'
-const censorFnWithPath = (v, p) => v + '.'
+const censorFnWithPath = (v, p) => v + '.' + p
 
 const redactNoSerialize = fastRedact({ paths: ['a.b.c'], serialize: false })
 const redactWildNoSerialize = fastRedact({ paths: ['a.b.*'], serialize: false })

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -4,6 +4,7 @@ const noir = require('pino-noir')(['a.b.c'])
 const fastRedact = require('..')
 
 const censorFn = (v) => v + '.'
+const censorFnWithPath = (v, p) => v + '.'
 
 const redactNoSerialize = fastRedact({ paths: ['a.b.c'], serialize: false })
 const redactWildNoSerialize = fastRedact({ paths: ['a.b.*'], serialize: false })
@@ -16,6 +17,10 @@ const redactIntermediateWildMatchWildOutcome = fastRedact({ paths: ['a.*.c', 'a.
 const redactStaticMatchWildOutcome = fastRedact({ paths: ['a.b.c', 'a.d.a', 'a.d.b', 'a.d.c'] })
 const noirCensorFunction = require('pino-noir')(['a.b.*'], censorFn)
 const redactCensorFunction = fastRedact({ paths: ['a.b.*'], censor: censorFn, serialize: false })
+const redactIntermediateWildCensorFunction = fastRedact({ paths: ['a.*.c'], censor: censorFn, serialize: false })
+const redactCensorFunctionWithPath = fastRedact({ paths: ['a.d.b'], censor: censorFn, serialize: false })
+const redactWildCensorFunctionWithPath = fastRedact({ paths: ['a.d.*'], censor: censorFnWithPath, serialize: false })
+const redactIntermediateWildCensorFunctionWithPath = fastRedact({ paths: ['a.*.c'], censorFnWithPath, serialize: false })
 
 const getObj = () => ({
   a: {
@@ -161,6 +166,34 @@ var run = bench([
     const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactCensorFunction(obj)
+    }
+    setImmediate(cb)
+  },
+  function benchFastRedactCensorFunctionIntermediateWild (cb) {
+    const obj = getObj()
+    for (var i = 0; i < max; i++) {
+      redactIntermediateWildCensorFunction(obj)
+    }
+    setImmediate(cb)
+  },
+  function benchFastRedactCensorFunctionWithPath (cb) {
+    const obj = getObj()
+    for (var i = 0; i < max; i++) {
+      redactCensorFunctionWithPath(obj)
+    }
+    setImmediate(cb)
+  },
+  function benchFastRedactWildCensorFunctionWithPath (cb) {
+    const obj = getObj()
+    for (var i = 0; i < max; i++) {
+      redactWildCensorFunctionWithPath(obj)
+    }
+    setImmediate(cb)
+  },
+  function benchFastRedactIntermediateWildCensorFunctionWithPath (cb) {
+    const obj = getObj()
+    for (var i = 0; i < max; i++) {
+      redactIntermediateWildCensorFunctionWithPath(obj)
     }
     setImmediate(cb)
   }

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function fastRedact (opts = {}) {
     : 'censor' in opts ? opts.censor : DEFAULT_CENSOR
 
   const isCensorFct = typeof censor === 'function'
+  const censorFctTakesPath = isCensorFct && censor.length > 1
 
   if (paths.length === 0) return serialize || noop
 
@@ -42,7 +43,7 @@ function fastRedact (opts = {}) {
   const compileRestore = restorer({ secret, wcLen })
   const strict = 'strict' in opts ? opts.strict : true
 
-  return redactor({ secret, wcLen, serialize, strict, isCensorFct }, state({
+  return redactor({ secret, wcLen, serialize, strict, isCensorFct, censorFctTakesPath }, state({
     secret,
     censor,
     compileRestore,

--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -20,12 +20,15 @@ function groupRedact (o, path, censor, isCensorFct) {
   const target = get(o, path)
   if (target == null) return { keys: null, values: null, target: null, flat: true }
   const keys = Object.keys(target)
-  const length = keys.length
-  const values = new Array(length)
-  for (var i = 0; i < length; i++) {
-    const k = keys[i]
-    values[i] = target[k]
-    target[k] = isCensorFct ? censor(target[k]) : censor
+  const keysLength = keys.length
+  const pathLength = path.length
+  const pathWithKey = path.concat('')
+  const values = new Array(keysLength)
+  for (var i = 0; i < keysLength; i++) {
+    const key = keys[i]
+    pathWithKey[pathLength] = key
+    values[i] = target[key]
+    target[key] = isCensorFct ? censor(target[key], pathWithKey) : censor
   }
   return { keys, values, target, flat: true }
 }
@@ -42,10 +45,13 @@ function nestedRedact (store, o, path, ns, censor, isCensorFct) {
   const target = get(o, path)
   if (target == null) return
   const keys = Object.keys(target)
-  const length = keys.length
-  for (var i = 0; i < length; i++) {
+  const keysLength = keys.length
+  const pathLength = path.length
+  const pathWithKey = path.concat('')
+  for (var i = 0; i < keysLength; i++) {
     const key = keys[i]
-    const { value, parent, exists } = specialSet(target, key, ns, censor, isCensorFct)
+    pathWithKey[pathLength] = key
+    const { value, parent, exists } = specialSet(target, key, pathWithKey, ns, censor, isCensorFct)
 
     if (exists === true && parent !== null) {
       store.push({ key: ns[ns.length - 1], target: parent, value })
@@ -58,10 +64,10 @@ function has (obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop)
 }
 
-function specialSet (o, k, p, v, f) {
+function specialSet (o, k, pathWithKey, afterPath, censor, isCensorFct) {
+  const afterPathLen = afterPath.length
+  const lastPathIndex = afterPathLen - 1
   var i = -1
-  var l = p.length
-  var li = l - 1
   var n
   var nv
   var ov
@@ -69,22 +75,26 @@ function specialSet (o, k, p, v, f) {
   var exists = true
   ov = n = o[k]
   if (typeof n !== 'object') return { value: null, parent: null, exists }
-  while (n != null && ++i < l) {
-    k = p[i]
+  while (n != null && ++i < afterPathLen) {
+    k = afterPath[i]
     oov = ov
     if (!(k in n)) {
       exists = false
       break
     }
     ov = n[k]
-    nv = f ? v(ov) : v
-    nv = (i !== li) ? ov : nv
-    n[k] = (has(n, k) && nv === ov) || (nv === undefined && v !== undefined) ? n[k] : nv
+    nv = (i !== lastPathIndex)
+      ? ov
+      : (isCensorFct
+        ? censor(ov, pathWithKey.concat(afterPath))
+        : censor)
+    n[k] = (has(n, k) && nv === ov) || (nv === undefined && censor !== undefined) ? n[k] : nv
     n = n[k]
     if (typeof n !== 'object') break
   }
   return { value: ov, parent: oov, exists }
 }
+
 function get (o, p) {
   var i = -1
   var l = p.length

--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -22,13 +22,19 @@ function groupRedact (o, path, censor, isCensorFct) {
   const keys = Object.keys(target)
   const keysLength = keys.length
   const pathLength = path.length
-  const pathWithKey = path.concat('')
+  const pathWithKey = isCensorFct ? [...path, ''] : undefined
   const values = new Array(keysLength)
+
   for (var i = 0; i < keysLength; i++) {
     const key = keys[i]
-    pathWithKey[pathLength] = key
     values[i] = target[key]
-    target[key] = isCensorFct ? censor(target[key], pathWithKey) : censor
+
+    if (isCensorFct) {
+      pathWithKey[pathLength] = key
+      target[key] = censor(target[key], pathWithKey)
+    } else {
+      target[key] = censor
+    }
   }
   return { keys, values, target, flat: true }
 }
@@ -46,12 +52,10 @@ function nestedRedact (store, o, path, ns, censor, isCensorFct) {
   if (target == null) return
   const keys = Object.keys(target)
   const keysLength = keys.length
-  const pathLength = path.length
-  const pathWithKey = path.concat('')
   for (var i = 0; i < keysLength; i++) {
     const key = keys[i]
-    pathWithKey[pathLength] = key
-    const { value, parent, exists } = specialSet(target, key, pathWithKey, ns, censor, isCensorFct)
+    const { value, parent, exists } =
+      specialSet(target, key, path, ns, censor, isCensorFct)
 
     if (exists === true && parent !== null) {
       store.push({ key: ns[ns.length - 1], target: parent, value })
@@ -64,9 +68,10 @@ function has (obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop)
 }
 
-function specialSet (o, k, pathWithKey, afterPath, censor, isCensorFct) {
+function specialSet (o, k, path, afterPath, censor, isCensorFct) {
   const afterPathLen = afterPath.length
   const lastPathIndex = afterPathLen - 1
+  const originalKey = k
   var i = -1
   var n
   var nv
@@ -86,7 +91,7 @@ function specialSet (o, k, pathWithKey, afterPath, censor, isCensorFct) {
     nv = (i !== lastPathIndex)
       ? ov
       : (isCensorFct
-        ? censor(ov, pathWithKey.concat(afterPath))
+        ? censor(ov, [...path, originalKey, ...afterPath])
         : censor)
     n[k] = (has(n, k) && nv === ov) || (nv === undefined && censor !== undefined) ? n[k] : nv
     n = n[k]

--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -16,22 +16,24 @@ function groupRestore ({ keys, values, target }) {
   }
 }
 
-function groupRedact (o, path, censor, isCensorFct) {
+function groupRedact (o, path, censor, isCensorFct, censorFctTakesPath) {
   const target = get(o, path)
   if (target == null) return { keys: null, values: null, target: null, flat: true }
   const keys = Object.keys(target)
   const keysLength = keys.length
   const pathLength = path.length
-  const pathWithKey = isCensorFct ? [...path] : undefined
+  const pathWithKey = censorFctTakesPath ? [...path] : undefined
   const values = new Array(keysLength)
 
   for (var i = 0; i < keysLength; i++) {
     const key = keys[i]
     values[i] = target[key]
 
-    if (isCensorFct) {
+    if (censorFctTakesPath) {
       pathWithKey[pathLength] = key
       target[key] = censor(target[key], pathWithKey)
+    } else if (isCensorFct) {
+      target[key] = censor(target[key])
     } else {
       target[key] = censor
     }
@@ -47,7 +49,7 @@ function nestedRestore (arr) {
   }
 }
 
-function nestedRedact (store, o, path, ns, censor, isCensorFct) {
+function nestedRedact (store, o, path, ns, censor, isCensorFct, censorFctTakesPath) {
   const target = get(o, path)
   if (target == null) return
   const keys = Object.keys(target)
@@ -55,7 +57,7 @@ function nestedRedact (store, o, path, ns, censor, isCensorFct) {
   for (var i = 0; i < keysLength; i++) {
     const key = keys[i]
     const { value, parent, exists } =
-      specialSet(target, key, path, ns, censor, isCensorFct)
+      specialSet(target, key, path, ns, censor, isCensorFct, censorFctTakesPath)
 
     if (exists === true && parent !== null) {
       store.push({ key: ns[ns.length - 1], target: parent, value })
@@ -68,7 +70,7 @@ function has (obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop)
 }
 
-function specialSet (o, k, path, afterPath, censor, isCensorFct) {
+function specialSet (o, k, path, afterPath, censor, isCensorFct, censorFctTakesPath) {
   const afterPathLen = afterPath.length
   const lastPathIndex = afterPathLen - 1
   const originalKey = k
@@ -91,7 +93,7 @@ function specialSet (o, k, path, afterPath, censor, isCensorFct) {
     nv = (i !== lastPathIndex)
       ? ov
       : (isCensorFct
-        ? censor(ov, [...path, originalKey, ...afterPath])
+        ? (censorFctTakesPath ? censor(ov, [...path, originalKey, ...afterPath]) : censor(ov))
         : censor)
     n[k] = (has(n, k) && nv === ov) || (nv === undefined && censor !== undefined) ? n[k] : nv
     n = n[k]

--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -22,7 +22,7 @@ function groupRedact (o, path, censor, isCensorFct) {
   const keys = Object.keys(target)
   const keysLength = keys.length
   const pathLength = path.length
-  const pathWithKey = isCensorFct ? [...path, ''] : undefined
+  const pathWithKey = isCensorFct ? [...path] : undefined
   const values = new Array(keysLength)
 
   for (var i = 0; i < keysLength; i++) {

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -4,7 +4,7 @@ const rx = require('./rx')
 
 module.exports = redactor
 
-function redactor ({ secret, serialize, wcLen, strict, isCensorFct }, state) {
+function redactor ({ secret, serialize, wcLen, strict, isCensorFct, censorFctTakesPath }, state) {
   /* eslint-disable-next-line */
   const redact = Function('o', `
     if (typeof o !== 'object' || o == null) {
@@ -13,7 +13,7 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct }, state) {
     const { censor, secret } = this
     ${redactTmpl(secret, isCensorFct)}
     this.compileRestore()
-    ${dynamicRedactTmpl(wcLen > 0, isCensorFct)}
+    ${dynamicRedactTmpl(wcLen > 0, isCensorFct, censorFctTakesPath)}
     ${resultTmpl(serialize)}
   `).bind(state)
 
@@ -64,7 +64,7 @@ function redactTmpl (secret, isCensorFct) {
   }).join('\n')
 }
 
-function dynamicRedactTmpl (hasWildcards, isCensorFct) {
+function dynamicRedactTmpl (hasWildcards, isCensorFct, censorFctTakesPath) {
   return hasWildcards === true ? `
     {
       const { wildcards, wcLen, groupRedact, nestedRedact } = this
@@ -72,8 +72,8 @@ function dynamicRedactTmpl (hasWildcards, isCensorFct) {
         const { before, beforeStr, after, nested } = wildcards[i]
         if (nested === true) {
           secret[beforeStr] = secret[beforeStr] || []
-          nestedRedact(secret[beforeStr], o, before, after, censor, ${isCensorFct})
-        } else secret[beforeStr] = groupRedact(o, before, censor, ${isCensorFct})
+          nestedRedact(secret[beforeStr], o, before, after, censor, ${isCensorFct}, ${censorFctTakesPath})
+        } else secret[beforeStr] = groupRedact(o, before, censor, ${isCensorFct}, ${censorFctTakesPath})
       }
     }
   ` : ''

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -26,7 +26,7 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct }, state) {
 
 function redactTmpl (secret, isCensorFct) {
   return Object.keys(secret).map((path) => {
-    const { escPath, leadingBracket } = secret[path]
+    const { escPath, leadingBracket, path: arrPath } = secret[path]
     const skip = leadingBracket ? 1 : 0
     const delim = leadingBracket ? '' : '.'
     const hops = []
@@ -56,7 +56,7 @@ function redactTmpl (secret, isCensorFct) {
           secret[${escPath}].precensored = true
         } else {
           secret[${escPath}].val = val
-          o${delim}${path} = ${isCensorFct ? 'censor(val)' : 'censor'}
+          o${delim}${path} = ${isCensorFct ? `censor(val, ${JSON.stringify(arrPath)})` : 'censor'}
           ${circularDetection}
         }
       }

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -11,7 +11,7 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct, censorFctTak
       ${strictImpl(strict, serialize)}
     }
     const { censor, secret } = this
-    ${redactTmpl(secret, isCensorFct)}
+    ${redactTmpl(secret, isCensorFct, censorFctTakesPath)}
     this.compileRestore()
     ${dynamicRedactTmpl(wcLen > 0, isCensorFct, censorFctTakesPath)}
     ${resultTmpl(serialize)}
@@ -24,7 +24,7 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct, censorFctTak
   return redact
 }
 
-function redactTmpl (secret, isCensorFct) {
+function redactTmpl (secret, isCensorFct, censorFctTakesPath) {
   return Object.keys(secret).map((path) => {
     const { escPath, leadingBracket, path: arrPath } = secret[path]
     const skip = leadingBracket ? 1 : 0
@@ -49,6 +49,11 @@ function redactTmpl (secret, isCensorFct) {
         `).join('\n')}
       }
     `
+
+    const censorArgs = censorFctTakesPath
+      ? `val, ${JSON.stringify(arrPath)}`
+      : `val`
+
     return `
       if (${existence}) {
         const val = o${delim}${path}
@@ -56,7 +61,7 @@ function redactTmpl (secret, isCensorFct) {
           secret[${escPath}].precensored = true
         } else {
           secret[${escPath}].val = val
-          o${delim}${path} = ${isCensorFct ? `censor(val, ${JSON.stringify(arrPath)})` : 'censor'}
+          o${delim}${path} = ${isCensorFct ? `censor(${censorArgs})` : 'censor'}
           ${circularDetection}
         }
       }

--- a/lib/state.js
+++ b/lib/state.js
@@ -6,7 +6,6 @@ function state (o) {
   const {
     secret,
     censor,
-    isCensorFct,
     compileRestore,
     serialize,
     groupRedact,
@@ -14,8 +13,7 @@ function state (o) {
     wildcards,
     wcLen
   } = o
-  const builder = [{ secret, censor, isCensorFct, compileRestore }]
-  builder.push({ secret })
+  const builder = [{ secret, censor, compileRestore }]
   if (serialize !== false) builder.push({ serialize })
   if (wcLen > 0) builder.push({ groupRedact, nestedRedact, wildcards, wcLen })
   return Object.assign(...builder)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-redact",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "very fast object redaction",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-redact",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "very fast object redaction",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const fastRedact = require('..')
 
 const censor = '[REDACTED]'
-const censorFct = value => !value ? value : 'xxx' + value.substr(-2)
+const censorFct = (value, path) => !value ? value : 'xxx' + value.substr(-2) + path.join('.')
 
 test('returns no-op when passed no paths [serialize: false]', ({ end, doesNotThrow }) => {
   const redact = fastRedact({ paths: [], serialize: false })
@@ -230,20 +230,20 @@ test('redact.restore function places original values back in place', ({ end, is 
 
 test('masks according to supplied censor function', ({ end, is }) => {
   const redact = fastRedact({ paths: ['a'], censor: censorFct, serialize: false })
-  is(redact({ a: '0123456' }).a, 'xxx56')
+  is(redact({ a: '0123456' }).a, 'xxx56a')
   end()
 })
 
 test('masks according to supplied censor function with wildcards', ({ end, is }) => {
   const redact = fastRedact({ paths: '*', censor: censorFct, serialize: false })
-  is(redact({ a: '0123456' }).a, 'xxx56')
+  is(redact({ a: '0123456' }).a, 'xxx56a')
   end()
 })
 
 test('masks according to supplied censor function with nested wildcards', ({ end, is }) => {
   const redact = fastRedact({ paths: ['*.b'], censor: censorFct, serialize: false })
-  is(redact({ a: { b: '0123456' } }).a.b, 'xxx56')
-  is(redact({ c: { b: '0123456', d: 'pristine' } }).c.b, 'xxx56')
+  is(redact({ a: { b: '0123456' } }).a.b, 'xxx56a.b')
+  is(redact({ c: { b: '0123456', d: 'pristine' } }).c.b, 'xxx56c.b')
   is(redact({ c: { b: '0123456', d: 'pristine' } }).c.d, 'pristine')
   end()
 })
@@ -252,7 +252,7 @@ test('redact.restore function places original values back in place with censor f
   const redact = fastRedact({ paths: ['a'], censor: censorFct, serialize: false })
   const o = { a: 'qwerty' }
   redact(o)
-  is(o.a, 'xxxty')
+  is(o.a, 'xxxtya')
   redact.restore(o)
   is(o.a, 'qwerty')
   end()


### PR DESCRIPTION
This PR calls the user's censor function with the path being censored as the second argument. I'm trying to support two different use cases here:

1. Sometimes different keys need to be redacted in different ways. For example, on an object representing a bank account, you might censor the account number by `xxxx`-ing out most of the numbers (but still leave a few for debugging), while censoring the account owner's name by removing it completely:

    ```js
    censor: (v, path) => path[path.length - 1] === 'accountNumber' 
      ? `xxxxxx${v.substr(-4)}` 
      : '[Redacted]'
    ```

2. Because fast-redact serializes the redacted object rather than returning a deep clone (for well-explained reasons), it's difficult to compose redaction logic. For example, suppose I have a few different business objects, like bank accounts, clients, etc., and that I want to define a separate redaction function for each object (in the same place where I define the object's schema etc). For example, I might define `redactAccount` as:
    ```js
    const censorAccount; // same censor function shown above
    const accountSecretPaths = ["accountNumber", "otherSecretPath"];
    const redactAccount = fastRedact({
      paths: accountSecretPaths, 
      censor: censorAccount
    });
    ```

    Now, suppose I need to log a redacted version of an object like: 

    ```js
    { clients: [...], accounts: [...] }
    ```

     If my `redactAccount` et al functions returned censored objects, rather than strings, this would be as simple as: 

    ```js
    log({ clients: [...].map(redactClient), accounts: [...].map(redactAccount) })
    ```

    So, my thought is that, by passing the path to `censor` functions, it becomes possible to support cases like this. I.e., I can now define a `composedRedact` function like so:

    ```js
    const opts = {
      paths: [
        ...accountSecretPaths.map(it => `accounts.*.${it}`),
        ...clientSecretPaths.map(it => `clients.*.${it}`)
      ],
      censor: (v, path) => path[0] === 'clients' 
        ? censorClient(v, path.slice(2))
        : censorAccount(v, path.slice(2));
    };

    const composedRedact = fastRedact(opts);
    ```

     Fwiw, I explored approaches to composition that leveraged `serialize: false` and `restore()`, but ran up against the wall that the state stored internally for each redaction function returned by `fastRedact` only covers the last object redacted, so it wasn't possible to redact a bunch of objects without serialization, collect and serialize the results, and then restore all of them.

    Given that limitation, I couldn't think of an approach for supporting composition that, at least absent a major refactor, wouldn't, under the hood, do more or less what the above `opts.censor` and `opts.paths` are doing explicitly. (Although I certainly can imagine some more convenient APIs that could be added to abstract that basic logic.)