### PR TITLE
chore: add files to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
 .nyc_output
+.travis.yml
+benchmark/
+example/
+test/


### PR DESCRIPTION
This should reduce size of published package from 136k to 60k