### PR TITLE
rework benchmarks

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -2,6 +2,9 @@
 const bench = require('fastbench')
 const noir = require('pino-noir')(['a.b.c'])
 const fastRedact = require('..')
+
+const censorFn = (v) => v + '.';
+
 const redactNoSerialize = fastRedact({ paths: ['a.b.c'], serialize: false })
 const redactWildNoSerialize = fastRedact({ paths: ['a.b.*'], serialize: false })
 const redactIntermediateWildNoSerialize = fastRedact({ paths: ['a.*.c'], serialize: false })
@@ -11,10 +14,10 @@ const redactWild = fastRedact({ paths: ['a.b.*'] })
 const redactIntermediateWild = fastRedact({ paths: ['a.*.c'] })
 const redactIntermediateWildMatchWildOutcome = fastRedact({ paths: ['a.*.c', 'a.*.b', 'a.*.a'] })
 const redactStaticMatchWildOutcome = fastRedact({ paths: ['a.b.c', 'a.d.a', 'a.d.b', 'a.d.c'] })
-const noirCensorFunction = require('pino-noir')(['a.b.*'], (v) => v + '.')
-const redactCensorFunction = fastRedact({ paths: ['a.b.*'], censor: (v) => v + '.', serialize: false })
+const noirCensorFunction = require('pino-noir')(['a.b.*'], censorFn)
+const redactCensorFunction = fastRedact({ paths: ['a.b.*'], censor: censorFn, serialize: false })
 
-const obj = {
+const getObj = () => ({
   a: {
     b: {
       c: 's'
@@ -25,24 +28,27 @@ const obj = {
       c: 's'
     }
   }
-}
+});
 
 const max = 500
 
 var run = bench([
   function benchNoirV2 (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       noir.a(obj.a)
     }
     setImmediate(cb)
   },
   function benchFastRedact (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactNoSerialize(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactRestore (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactNoSerialize(obj)
       redactNoSerialize.restore(obj)
@@ -50,18 +56,21 @@ var run = bench([
     setImmediate(cb)
   },
   function benchNoirV2Wild (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       noirWild.a(obj.a)
     }
     setImmediate(cb)
   },
   function benchFastRedactWild (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactWildNoSerialize(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactWildRestore (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactWildNoSerialize(obj)
       redactWildNoSerialize.restore(obj)
@@ -69,12 +78,14 @@ var run = bench([
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWild (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactIntermediateWildNoSerialize(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWildRestore (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactIntermediateWildNoSerialize(obj)
       redactIntermediateWildNoSerialize.restore(obj)
@@ -82,12 +93,14 @@ var run = bench([
     setImmediate(cb)
   },
   function benchJSONStringify (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       JSON.stringify(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2Serialize (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       noir.a(obj.a)
       JSON.stringify(obj)
@@ -95,12 +108,14 @@ var run = bench([
     setImmediate(cb)
   },
   function benchFastRedactSerialize (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redact(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2WildSerialize (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       noirWild.a(obj.a)
       JSON.stringify(obj)
@@ -108,36 +123,42 @@ var run = bench([
     setImmediate(cb)
   },
   function benchFastRedactWildSerialize (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactWild(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWildSerialize (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactIntermediateWild(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWildMatchWildOutcomeSerialize (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactIntermediateWildMatchWildOutcome(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactStaticMatchWildOutcomeSerialize (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactStaticMatchWildOutcome(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2CensorFunction (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       noirCensorFunction.a(obj.a)
     }
     setImmediate(cb)
   },
   function benchFastRedactCensorFunction (cb) {
+    const obj = getObj();
     for (var i = 0; i < max; i++) {
       redactCensorFunction(obj)
     }

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -3,7 +3,7 @@ const bench = require('fastbench')
 const noir = require('pino-noir')(['a.b.c'])
 const fastRedact = require('..')
 
-const censorFn = (v) => v + '.';
+const censorFn = (v) => v + '.'
 
 const redactNoSerialize = fastRedact({ paths: ['a.b.c'], serialize: false })
 const redactWildNoSerialize = fastRedact({ paths: ['a.b.*'], serialize: false })
@@ -28,27 +28,27 @@ const getObj = () => ({
       c: 's'
     }
   }
-});
+})
 
 const max = 500
 
 var run = bench([
   function benchNoirV2 (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       noir.a(obj.a)
     }
     setImmediate(cb)
   },
   function benchFastRedact (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactNoSerialize(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactRestore (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactNoSerialize(obj)
       redactNoSerialize.restore(obj)
@@ -56,21 +56,21 @@ var run = bench([
     setImmediate(cb)
   },
   function benchNoirV2Wild (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       noirWild.a(obj.a)
     }
     setImmediate(cb)
   },
   function benchFastRedactWild (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactWildNoSerialize(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactWildRestore (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactWildNoSerialize(obj)
       redactWildNoSerialize.restore(obj)
@@ -78,14 +78,14 @@ var run = bench([
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWild (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactIntermediateWildNoSerialize(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWildRestore (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactIntermediateWildNoSerialize(obj)
       redactIntermediateWildNoSerialize.restore(obj)
@@ -93,14 +93,14 @@ var run = bench([
     setImmediate(cb)
   },
   function benchJSONStringify (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       JSON.stringify(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2Serialize (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       noir.a(obj.a)
       JSON.stringify(obj)
@@ -108,14 +108,14 @@ var run = bench([
     setImmediate(cb)
   },
   function benchFastRedactSerialize (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redact(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2WildSerialize (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       noirWild.a(obj.a)
       JSON.stringify(obj)
@@ -123,42 +123,42 @@ var run = bench([
     setImmediate(cb)
   },
   function benchFastRedactWildSerialize (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactWild(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWildSerialize (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactIntermediateWild(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWildMatchWildOutcomeSerialize (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactIntermediateWildMatchWildOutcome(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactStaticMatchWildOutcomeSerialize (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactStaticMatchWildOutcome(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2CensorFunction (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       noirCensorFunction.a(obj.a)
     }
     setImmediate(cb)
   },
   function benchFastRedactCensorFunction (cb) {
-    const obj = getObj();
+    const obj = getObj()
     for (var i = 0; i < max; i++) {
       redactCensorFunction(obj)
     }

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,24 +1,29 @@
 'use strict'
 const bench = require('fastbench')
-const noir = require('pino-noir')(['a.b.c'])
 const fastRedact = require('..')
 
 const censorFn = (v) => v + '.'
 
-const redactNoSerialize = fastRedact({ paths: ['a.b.c'], serialize: false })
-const redactWildNoSerialize = fastRedact({ paths: ['a.b.*'], serialize: false })
-const redactIntermediateWildNoSerialize = fastRedact({ paths: ['a.*.c'], serialize: false })
-const redact = fastRedact({ paths: ['a.b.c'] })
-const noirWild = require('pino-noir')(['a.b.*'])
-const redactWild = fastRedact({ paths: ['a.b.*'] })
-const redactIntermediateWild = fastRedact({ paths: ['a.*.c'] })
-const redactIntermediateWildMatchWildOutcome = fastRedact({ paths: ['a.*.c', 'a.*.b', 'a.*.a'] })
-const redactStaticMatchWildOutcome = fastRedact({ paths: ['a.b.c', 'a.d.a', 'a.d.b', 'a.d.c'] })
-const noirCensorFunction = require('pino-noir')(['a.b.*'], censorFn)
-const redactCensorFunction = fastRedact({ paths: ['a.b.*'], censor: censorFn, serialize: false })
+const noir = require('pino-noir')(['aa.b.c'])
+const redactNoSerialize = fastRedact({ paths: ['ab.b.c'], serialize: false })
+const redactNoSerializeRestore = fastRedact({ paths: ['ac.b.c'], serialize: false })
+const noirWild = require('pino-noir')(['ad.b.*'])
+const redactWildNoSerialize = fastRedact({ paths: ['ae.b.*'], serialize: false })
+const redactWildNoSerializeRestore = fastRedact({ paths: ['af.b.*'], serialize: false })
+const redactIntermediateWildNoSerialize = fastRedact({ paths: ['ag.*.c'], serialize: false })
+const redactIntermediateWildNoSerializeRestore = fastRedact({ paths: ['ah.*.c'], serialize: false })
+const noirJSONSerialize = require('pino-noir')(['aj.b.c']) // `ai` used in pure JSON test.
+const redact = fastRedact({ paths: ['ak.b.c'] })
+const noirWildJSONSerialize = require('pino-noir')(['al.b.c'])
+const redactWild = fastRedact({ paths: ['am.b.*'] })
+const redactIntermediateWild = fastRedact({ paths: ['an.*.c'] })
+const redactIntermediateWildMatchWildOutcome = fastRedact({ paths: ['ao.*.c', 'ao.*.b', 'ao.*.a'] })
+const redactStaticMatchWildOutcome = fastRedact({ paths: ['ap.b.c', 'ap.d.a', 'ap.d.b', 'ap.d.c'] })
+const noirCensorFunction = require('pino-noir')(['aq.b.*'], censorFn)
+const redactCensorFunction = fastRedact({ paths: ['ar.b.*'], censor: censorFn, serialize: false })
 
-const getObj = () => ({
-  a: {
+const getObj = (outerKey) => ({
+  [outerKey]: {
     b: {
       c: 's'
     },
@@ -34,131 +39,131 @@ const max = 500
 
 var run = bench([
   function benchNoirV2 (cb) {
-    const obj = getObj()
+    const obj = getObj('aa')
     for (var i = 0; i < max; i++) {
-      noir.a(obj.a)
+      noir.aa(obj.aa)
     }
     setImmediate(cb)
   },
   function benchFastRedact (cb) {
-    const obj = getObj()
+    const obj = getObj('ab')
     for (var i = 0; i < max; i++) {
       redactNoSerialize(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactRestore (cb) {
-    const obj = getObj()
+    const obj = getObj('ac')
     for (var i = 0; i < max; i++) {
-      redactNoSerialize(obj)
-      redactNoSerialize.restore(obj)
+      redactNoSerializeRestore(obj)
+      redactNoSerializeRestore.restore(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2Wild (cb) {
-    const obj = getObj()
+    const obj = getObj('ad')
     for (var i = 0; i < max; i++) {
-      noirWild.a(obj.a)
+      noirWild.ad(obj.ad)
     }
     setImmediate(cb)
   },
   function benchFastRedactWild (cb) {
-    const obj = getObj()
+    const obj = getObj('ae')
     for (var i = 0; i < max; i++) {
       redactWildNoSerialize(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactWildRestore (cb) {
-    const obj = getObj()
+    const obj = getObj('af')
     for (var i = 0; i < max; i++) {
-      redactWildNoSerialize(obj)
-      redactWildNoSerialize.restore(obj)
+      redactWildNoSerializeRestore(obj)
+      redactWildNoSerializeRestore.restore(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWild (cb) {
-    const obj = getObj()
+    const obj = getObj('ag')
     for (var i = 0; i < max; i++) {
       redactIntermediateWildNoSerialize(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWildRestore (cb) {
-    const obj = getObj()
+    const obj = getObj('ah')
     for (var i = 0; i < max; i++) {
-      redactIntermediateWildNoSerialize(obj)
-      redactIntermediateWildNoSerialize.restore(obj)
+      redactIntermediateWildNoSerializeRestore(obj)
+      redactIntermediateWildNoSerializeRestore.restore(obj)
     }
     setImmediate(cb)
   },
   function benchJSONStringify (cb) {
-    const obj = getObj()
+    const obj = getObj('ai')
     for (var i = 0; i < max; i++) {
       JSON.stringify(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2Serialize (cb) {
-    const obj = getObj()
+    const obj = getObj('aj')
     for (var i = 0; i < max; i++) {
-      noir.a(obj.a)
+      noirJSONSerialize.aj(obj.aj)
       JSON.stringify(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactSerialize (cb) {
-    const obj = getObj()
+    const obj = getObj('ak')
     for (var i = 0; i < max; i++) {
       redact(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2WildSerialize (cb) {
-    const obj = getObj()
+    const obj = getObj('al')
     for (var i = 0; i < max; i++) {
-      noirWild.a(obj.a)
+      noirWildJSONSerialize.al(obj.al)
       JSON.stringify(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactWildSerialize (cb) {
-    const obj = getObj()
+    const obj = getObj('am')
     for (var i = 0; i < max; i++) {
       redactWild(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWildSerialize (cb) {
-    const obj = getObj()
+    const obj = getObj('an')
     for (var i = 0; i < max; i++) {
       redactIntermediateWild(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactIntermediateWildMatchWildOutcomeSerialize (cb) {
-    const obj = getObj()
+    const obj = getObj('ao')
     for (var i = 0; i < max; i++) {
       redactIntermediateWildMatchWildOutcome(obj)
     }
     setImmediate(cb)
   },
   function benchFastRedactStaticMatchWildOutcomeSerialize (cb) {
-    const obj = getObj()
+    const obj = getObj('ap')
     for (var i = 0; i < max; i++) {
       redactStaticMatchWildOutcome(obj)
     }
     setImmediate(cb)
   },
   function benchNoirV2CensorFunction (cb) {
-    const obj = getObj()
+    const obj = getObj('aq')
     for (var i = 0; i < max; i++) {
-      noirCensorFunction.a(obj.a)
+      noirCensorFunction.aq(obj.aq)
     }
     setImmediate(cb)
   },
   function benchFastRedactCensorFunction (cb) {
-    const obj = getObj()
+    const obj = getObj('ar')
     for (var i = 0; i < max; i++) {
       redactCensorFunction(obj)
     }

--- a/lib/rx.js
+++ b/lib/rx.js
@@ -2,15 +2,15 @@
 
 module.exports = /[^.[\]]+|\[((?:.)*?)\]/g
 
-/* 
+/*
 Regular expression explanation:
 
-Alt 1: /[^.[\]]+/ - Match one or more characters that are *not* a dot (.) 
+Alt 1: /[^.[\]]+/ - Match one or more characters that are *not* a dot (.)
                     opening square bracket ([) or closing square bracket (])
 
 Alt 2: /\[((?:.)*?)\]/ - If the char IS dot or square bracket, then create a capture
-                         group (which will be capture group $1) that matches anything 
+                         group (which will be capture group $1) that matches anything
                          within square brackets. Expansion is lazy so it will
-                         stop matching as soon as the first closing bracket is met `]` 
+                         stop matching as soon as the first closing bracket is met `]`
                          (rather than continuing to match until the final closing bracket).
 */


### PR DESCRIPTION
This creates a new object before each benchmark's loop, which should make the benchmarks more reliable (since hidden class transitions on the object from prior tests could effect the speed of the redaction). This doesn’t go as far as to create a new object right before each redaction call (i.e., in the `for` loop) as that seems like it would add more noise/difficulty interpreting the final results, since a bigger chunk of each benchmark’s work would be this object creation.

This also means that the `serialize: false` tests (and the pino-noir tests, which are effectively serialize false) don’t leave the object in a different state for the subsequent tests, which is required for adding tests for #16. [That's what motivated me to make this change.]

Most of the benchmark times remained similar before and after this change, with some of the fast-redact benchmarks getting 10-30% faster [but idk how much of that is noise]. A few benchmarks seemed to show consistent differences of greater than 30%:

- `benchNoirV2` (the first case): about 50% faster [consistently],  for
reasons I don’t quite understand.

- `benchFastRedactRestore`: about 50% faster

- `benchFastRedactIntermediateWild`: about 50% slower

- `benchNoirV2Wild`,`benchNoirV2CensorFunction`, `benchNoirV2Wild`,
`benchNoirV2CensorFunction`: 2-4x as fast

- `benchFastRedactCensorFunction`: 50-100% faster

Here are the full results:

# Before [ran twice, and the results were pretty similar]

benchNoirV2*500: 84.279ms
benchFastRedact*500: 14.280ms
benchFastRedactRestore*500: 22.773ms
benchNoirV2Wild*500: 105.580ms
benchFastRedactWild*500: 40.533ms
benchFastRedactWildRestore*500: 41.080ms
benchFastRedactIntermediateWild*500: 107.193ms
benchFastRedactIntermediateWildRestore*500: 92.896ms
benchJSONStringify*500: 323.536ms
benchNoirV2Serialize*500: 407.667ms
benchFastRedactSerialize*500: 337.723ms
benchNoirV2WildSerialize*500: 380.418ms
benchFastRedactWildSerialize*500: 372.057ms
benchFastRedactIntermediateWildSerialize*500: 417.458ms
benchFastRedactIntermediateWildMatchWildOutcomeSerialize*500: 572.464ms
benchFastRedactStaticMatchWildOutcomeSerialize*500: 348.632ms
benchNoirV2CensorFunction*500: 70.804ms
benchFastRedactCensorFunction*500: 59.476ms
benchNoirV2*500: 48.808ms
benchFastRedact*500: 11.550ms
benchFastRedactRestore*500: 13.436ms
benchNoirV2Wild*500: 61.383ms
benchFastRedactWild*500: 31.472ms
benchFastRedactWildRestore*500: 34.325ms
benchFastRedactIntermediateWild*500: 128.071ms
benchFastRedactIntermediateWildRestore*500: 128.602ms
benchJSONStringify*500: 317.474ms
benchNoirV2Serialize*500: 395.179ms
benchFastRedactSerialize*500: 323.449ms
benchNoirV2WildSerialize*500: 369.051ms
benchFastRedactWildSerialize*500: 356.204ms
benchFastRedactIntermediateWildSerialize*500: 426.994ms
benchFastRedactIntermediateWildMatchWildOutcomeSerialize*500: 531.789ms
benchFastRedactStaticMatchWildOutcomeSerialize*500: 340.540ms
benchNoirV2CensorFunction*500: 38.953ms
benchFastRedactCensorFunction*500: 53.361ms

# After [ran twice, and the results were pretty similar]

benchNoirV2*500: 54.057ms
benchFastRedact*500: 15.949ms
benchFastRedactRestore*500: 13.749ms
benchNoirV2Wild*500: 34.787ms
benchFastRedactWild*500: 44.642ms
benchFastRedactWildRestore*500: 42.949ms
benchFastRedactIntermediateWild*500: 162.311ms
benchFastRedactIntermediateWildRestore*500: 106.921ms
benchJSONStringify*500: 306.766ms
benchNoirV2Serialize*500: 403.440ms
benchFastRedactSerialize*500: 321.294ms
benchNoirV2WildSerialize*500: 366.650ms
benchFastRedactWildSerialize*500: 342.946ms
benchFastRedactIntermediateWildSerialize*500: 437.797ms
benchFastRedactIntermediateWildMatchWildOutcomeSerialize*500: 573.556ms
benchFastRedactStaticMatchWildOutcomeSerialize*500: 336.521ms
benchNoirV2CensorFunction*500: 27.110ms
benchFastRedactCensorFunction*500: 47.454ms
benchNoirV2*500: 38.437ms
benchFastRedact*500: 10.272ms
benchFastRedactRestore*500: 9.693ms
benchNoirV2Wild*500: 18.504ms
benchFastRedactWild*500: 30.266ms
benchFastRedactWildRestore*500: 35.108ms
benchFastRedactIntermediateWild*500: 131.794ms
benchFastRedactIntermediateWildRestore*500: 110.691ms
benchJSONStringify*500: 299.861ms
benchNoirV2Serialize*500: 384.236ms
benchFastRedactSerialize*500: 314.049ms
benchNoirV2WildSerialize*500: 365.485ms
benchFastRedactWildSerialize*500: 344.158ms
benchFastRedactIntermediateWildSerialize*500: 426.421ms
benchFastRedactIntermediateWildMatchWildOutcomeSerialize*500: 537.079ms
benchFastRedactStaticMatchWildOutcomeSerialize*500: 340.104ms
benchNoirV2CensorFunction*500: 16.021ms
benchFastRedactCensorFunction*500: 31.100ms