### PR TITLE
Properly restore values matching multiple paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const restorer = require('./lib/restorer')
 const { groupRedact, nestedRedact } = require('./lib/modifiers')
 const state = require('./lib/state')
 const rx = require('./lib/rx')
+const createStash = require('./lib/stash')
 const validate = validator()
 const noop = (o) => o
 noop.restore = noop
@@ -47,6 +48,7 @@ function fastRedact (opts = {}) {
     secret,
     censor,
     compileRestore,
+    createStash,
     serialize,
     groupRedact,
     nestedRedact,

--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -7,30 +7,31 @@ module.exports = {
   nestedRestore
 }
 
-function groupRestore ({ keys, values, target }) {
+function groupRestore ({ keys, path, target }) {
   if (target == null) return
+  const { getValue } = this.stash
   const length = keys.length
+  const pathWithKey = [...path]
+  const pathLength = path.length
   for (var i = 0; i < length; i++) {
     const k = keys[i]
-    target[k] = values[i]
+    pathWithKey[pathLength] = k
+    target[k] = getValue(pathWithKey)
   }
 }
 
-function groupRedact (o, path, censor, isCensorFct, censorFctTakesPath) {
+function groupRedact (o, path, censor, isCensorFct, censorFctTakesPath, { putValue }) {
   const target = get(o, path)
   if (target == null) return { keys: null, values: null, target: null, flat: true }
   const keys = Object.keys(target)
   const keysLength = keys.length
   const pathLength = path.length
-  const pathWithKey = censorFctTakesPath ? [...path] : undefined
-  const values = new Array(keysLength)
-
+  const pathWithKey = [...path]
   for (var i = 0; i < keysLength; i++) {
     const key = keys[i]
-    values[i] = target[key]
-
+    pathWithKey[pathLength] = key
+    putValue(pathWithKey, target[key])
     if (censorFctTakesPath) {
-      pathWithKey[pathLength] = key
       target[key] = censor(target[key], pathWithKey)
     } else if (isCensorFct) {
       target[key] = censor(target[key])
@@ -38,29 +39,31 @@ function groupRedact (o, path, censor, isCensorFct, censorFctTakesPath) {
       target[key] = censor
     }
   }
-  return { keys, values, target, flat: true }
+  return { keys, target, path, flat: true }
 }
 
 function nestedRestore (arr) {
   const length = arr.length
+  const { getValue } = this.stash
   for (var i = 0; i < length; i++) {
-    const { key, target, value } = arr[i]
-    target[key] = value
+    const { key, target, path } = arr[i]
+    target[key] = getValue(path)
   }
 }
 
-function nestedRedact (store, o, path, ns, censor, isCensorFct, censorFctTakesPath) {
+function nestedRedact (store, o, path, ns, censor, isCensorFct, censorFctTakesPath, { putValue }) {
   const target = get(o, path)
   if (target == null) return
   const keys = Object.keys(target)
   const keysLength = keys.length
   for (var i = 0; i < keysLength; i++) {
     const key = keys[i]
-    const { value, parent, exists } =
+    const { value, parent, exists, fullPath } =
       specialSet(target, key, path, ns, censor, isCensorFct, censorFctTakesPath)
 
     if (exists === true && parent !== null) {
-      store.push({ key: ns[ns.length - 1], target: parent, value })
+      putValue(fullPath, value)
+      store.push({ key: ns[ns.length - 1], target: parent, path: fullPath })
     }
   }
   return store
@@ -79,6 +82,7 @@ function specialSet (o, k, path, afterPath, censor, isCensorFct, censorFctTakesP
   var nv
   var ov
   var oov = null
+  var fullPath = null
   var exists = true
   ov = n = o[k]
   if (typeof n !== 'object') return { value: null, parent: null, exists }
@@ -90,16 +94,17 @@ function specialSet (o, k, path, afterPath, censor, isCensorFct, censorFctTakesP
       break
     }
     ov = n[k]
+    fullPath = [...path, originalKey, ...afterPath]
     nv = (i !== lastPathIndex)
       ? ov
       : (isCensorFct
-        ? (censorFctTakesPath ? censor(ov, [...path, originalKey, ...afterPath]) : censor(ov))
+        ? (censorFctTakesPath ? censor(ov, fullPath) : censor(ov))
         : censor)
     n[k] = (has(n, k) && nv === ov) || (nv === undefined && censor !== undefined) ? n[k] : nv
     n = n[k]
     if (typeof n !== 'object') break
   }
-  return { value: ov, parent: oov, exists }
+  return { value: ov, parent: oov, fullPath, exists }
 }
 
 function get (o, p) {

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -10,9 +10,11 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct, censorFctTak
     if (typeof o !== 'object' || o == null) {
       ${strictImpl(strict, serialize)}
     }
+    const stash = this.createStash()
     const { censor, secret } = this
+    const { getValue, putValue } = stash
     ${redactTmpl(secret, isCensorFct, censorFctTakesPath)}
-    this.compileRestore()
+    this.compileRestore(stash)
     ${dynamicRedactTmpl(wcLen > 0, isCensorFct, censorFctTakesPath)}
     ${resultTmpl(serialize)}
   `).bind(state)
@@ -61,6 +63,7 @@ function redactTmpl (secret, isCensorFct, censorFctTakesPath) {
           secret[${escPath}].precensored = true
         } else {
           secret[${escPath}].val = val
+          putValue(secret[${escPath}].path, val)
           o${delim}${path} = ${isCensorFct ? `censor(${censorArgs})` : 'censor'}
           ${circularDetection}
         }
@@ -77,8 +80,8 @@ function dynamicRedactTmpl (hasWildcards, isCensorFct, censorFctTakesPath) {
         const { before, beforeStr, after, nested } = wildcards[i]
         if (nested === true) {
           secret[beforeStr] = secret[beforeStr] || []
-          nestedRedact(secret[beforeStr], o, before, after, censor, ${isCensorFct}, ${censorFctTakesPath})
-        } else secret[beforeStr] = groupRedact(o, before, censor, ${isCensorFct}, ${censorFctTakesPath})
+          nestedRedact(secret[beforeStr], o, before, after, censor, ${isCensorFct}, ${censorFctTakesPath}, stash)
+        } else secret[beforeStr] = groupRedact(o, before, censor, ${isCensorFct}, ${censorFctTakesPath}, stash)
       }
     }
   ` : ''

--- a/lib/restorer.js
+++ b/lib/restorer.js
@@ -5,13 +5,14 @@ const { groupRestore, nestedRestore } = require('./modifiers')
 module.exports = restorer
 
 function restorer ({ secret, wcLen }) {
-  return function compileRestore () {
+  return function compileRestore (stash) {
     if (this.restore) return
     const paths = Object.keys(secret)
       .filter((path) => secret[path].precensored === false)
     const resetters = resetTmpl(secret, paths)
     const hasWildcards = wcLen > 0
-    const state = hasWildcards ? { secret, groupRestore, nestedRestore } : { secret }
+    const state = { secret, stash }
+    if (hasWildcards) Object.assign(state, { groupRestore, nestedRestore })
     /* eslint-disable-next-line */
     this.restore = Function(
       'o',

--- a/lib/stash.js
+++ b/lib/stash.js
@@ -1,0 +1,41 @@
+'use strict'
+
+function pathToKey (path) {
+  return path.join('.')
+}
+
+/**
+ * Creates a stash that should act as a global
+ * registry of property values - used to store
+ * and restore them on the target object.
+ *
+ * The stash is global in the sense that each
+ * value is stored under its full path on the
+ * target object.
+ *
+ * Note:
+ * Only the first value stored for any given
+ * path is retained - all others are ignored -
+ * to guarantee the original values get not
+ * overwritten by redacted ones when a specific
+ * property matches mutiple `paths`.
+ *
+ * @returns a new stash
+ */
+function createStash () {
+  const map = new Map()
+  return {
+    getValue (path) {
+      const key = pathToKey(path)
+      return map.get(key)
+    },
+    putValue (path, value) {
+      const key = pathToKey(path)
+      if (!map.has(key)) {
+        map.set(key, value)
+      }
+    }
+  }
+}
+
+module.exports = createStash

--- a/lib/state.js
+++ b/lib/state.js
@@ -7,13 +7,14 @@ function state (o) {
     secret,
     censor,
     compileRestore,
+    createStash,
     serialize,
     groupRedact,
     nestedRedact,
     wildcards,
     wcLen
   } = o
-  const builder = [{ secret, censor, compileRestore }]
+  const builder = [{ secret, censor, compileRestore, createStash }]
   if (serialize !== false) builder.push({ serialize })
   if (wcLen > 0) builder.push({ groupRedact, nestedRedact, wildcards, wcLen })
   return Object.assign(...builder)

--- a/test/index.js
+++ b/test/index.js
@@ -987,6 +987,38 @@ test('correctly restores original object when a matching path has value of `unde
   end()
 })
 
+test('correctly restores keys matching a static path and a wildcard', ({ end, is }) => {
+  const redact = fastRedact({
+    paths: ['a', '*.b', 'x.b'],
+    serialize: false
+  })
+  const o = { x: { a: 'a', b: 'b' } }
+  redact(o)
+  is(o.x.a, 'a')
+  is(o.x.b, '[REDACTED]')
+  redact.restore(o)
+  is(o.x.a, 'a')
+  is(o.x.b, 'b')
+  end()
+})
+
+test('correctly restores keys matching multiple wildcards', ({ end, is }) => {
+  const redact = fastRedact({
+    paths: ['a', '*.b', 'x.*', 'y.*.z'],
+    serialize: false
+  })
+  const o = { x: { a: 'a', b: 'b' }, y: { f: { z: 'z' } } }
+  redact(o)
+  is(o.x.a, '[REDACTED]')
+  is(o.x.b, '[REDACTED]')
+  is(o.y.f.z, '[REDACTED]')
+  redact.restore(o)
+  is(o.x.a, 'a')
+  is(o.x.b, 'b')
+  is(o.y.f.z, 'z')
+  end()
+})
+
 test('handles multiple paths with leading brackets', ({ end, is }) => {
   const redact = fastRedact({ paths: ['["x-y"]', '["y-x"]'] })
   const o = { 'x-y': 'test', 'y-x': 'test2' }


### PR DESCRIPTION
Fixes #33 

## The issue

Each path type (static, group, nested)
uses an **isolated** way of storing and restoring
values on the original object.

In case of a property that matches multiple
redaction paths, this isolation leads to loss
of information as it fails to restore the
original value on the original mutated object.

The issue can be reproduced with the following:

```js
const redact = fastRedact({
  paths: ['a', '*.b', 'x.b'],
  serialize: false
})
const o = {
  x: {
    a: 'a',
    b: 'b'
  }
}
redact(o)
```

In this example `x.b` would match both the static `x.b`
path and the wildcard `*.b` path leading in the original
object being restored as:

```
{
  x: {
    a: 'a',
    b: '[REDACTED]'
  }
}
```

## The fix

This fix tackles the problem by introducing a global `stash` that is shared
across the various (static, group, nested) redaction types, protecting a redaction
from overwriting an original value with a redacted value produced from
a previous redaction.