### PR TITLE
fix: properly restore values matching multiple paths

### DIFF
--- a/lib/restorer.js
+++ b/lib/restorer.js
@@ -49,11 +49,26 @@ function resetTmpl (secret, paths) {
   }).join('')
 }
 
+/**
+ * Creates the body of the restore function
+ *
+ * Restoration of the redacted object happens
+ * backwards, in reverse order of redactions,
+ * so that repeated redactions on the same object
+ * property can be eventually rolled back to the
+ * original value.
+ *
+ * This way dynamic redactions are restored first,
+ * starting from the last one working backwards and
+ * followed by the static ones.
+ *
+ * @returns {string} the body of the restore function
+ */
 function restoreTmpl (resetters, paths, hasWildcards) {
   const dynamicReset = hasWildcards === true ? `
     const keys = Object.keys(secret)
     const len = keys.length
-    for (var i = ${paths.length}; i < len; i++) {
+    for (var i = len - 1; i >= ${paths.length}; i--) {
       const k = keys[i]
       const o = secret[k]
       if (o.flat === true) this.groupRestore(o)
@@ -64,8 +79,8 @@ function restoreTmpl (resetters, paths, hasWildcards) {
 
   return `
     const secret = this.secret
-    ${resetters}
     ${dynamicReset}
+    ${resetters}
     return o
   `
 }

--- a/test/index.js
+++ b/test/index.js
@@ -987,6 +987,38 @@ test('correctly restores original object when a matching path has value of `unde
   end()
 })
 
+test('correctly restores keys matching a static path and a wildcard', ({ end, is }) => {
+  const redact = fastRedact({
+    paths: ['a', '*.b', 'x.b'],
+    serialize: false
+  })
+  const o = { x: { a: 'a', b: 'b' } }
+  redact(o)
+  is(o.x.a, 'a')
+  is(o.x.b, '[REDACTED]')
+  redact.restore(o)
+  is(o.x.a, 'a')
+  is(o.x.b, 'b')
+  end()
+})
+
+test('correctly restores keys matching multiple wildcards', ({ end, is }) => {
+  const redact = fastRedact({
+    paths: ['a', '*.b', 'x.*', 'y.*.z'],
+    serialize: false
+  })
+  const o = { x: { a: 'a', b: 'b' }, y: { f: { z: 'z' } } }
+  redact(o)
+  is(o.x.a, '[REDACTED]')
+  is(o.x.b, '[REDACTED]')
+  is(o.y.f.z, '[REDACTED]')
+  redact.restore(o)
+  is(o.x.a, 'a')
+  is(o.x.b, 'b')
+  is(o.y.f.z, 'z')
+  end()
+})
+
 test('handles multiple paths with leading brackets', ({ end, is }) => {
   const redact = fastRedact({ paths: ['["x-y"]', '["y-x"]'] })
   const o = { 'x-y': 'test', 'y-x': 'test2' }


### PR DESCRIPTION
Fixes #33 

## The fix

Restoration of the redacted object happens backwards, in reverse order of redactions,
so that repeated redactions on the same object property can be eventually rolled back 
to the original value.

This way dynamic redactions are restored first, starting from the last one working backwards 
and followed by the static ones.