### PR TITLE
Fixed: Error is thrown for wildcard paths vs object with nested nulls

### DIFF
--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -117,7 +117,7 @@ function specialSet (o, k, path, afterPath, censor, isCensorFct, censorFctTakesP
         const wck = wcKeys[j]
         const wcov = n[wck]
         const kIsWc = k === '*'
-        if (kIsWc || (typeof wcov === 'object' && k in wcov)) {
+        if (kIsWc || (typeof wcov === 'object' && wcov !== null && k in wcov)) {
           if (kIsWc) {
             ov = wcov
           } else {

--- a/test/index.js
+++ b/test/index.js
@@ -1237,3 +1237,14 @@ test('handles multi wildcards within arrays with undefined values', ({ end, is }
   is(redact(o), '{"a":[{"x":{"d":[{"i":"[REDACTED]","j":"NR"}]}}]}')
   end()
 })
+
+test('handles multi wildcards with objects containing nulls', ({ end, is }) => {
+  const redact = fastRedact({
+    paths: ['*.*.x'],
+    serialize: false,
+    censor: '[REDACTED]'
+  })
+  const o = { a: { b: null } }
+  is(redact(o), o)
+  end()
+})


### PR DESCRIPTION
As per title the following error was thrown when I was using path with multiple wildcards against an object with nulls

```
TypeError: Cannot use 'in' operator to search for 'x' in null
at specialSet (/workspace/lib-logger/node_modules/fast-redact/lib/modifiers.js:120:53)
at nestedRedact (/workspace/lib-logger/node_modules/fast-redact/lib/modifiers.js:73:7)
```

```
   const redact = fastRedact({
      paths: ['*.*.x'],
      serialize: false,
      censor: "[REDACTED]",
    });

    expect(redact({a: {b: null}})).toEqual({a: {b: null}});
```
