### PR TITLE
ci: update workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,31 @@ name: ci
 
 on: [push, pull_request]
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x]
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: npm
           node-version: ${{ matrix.node-version }}
 
       - name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          cache: npm
           node-version: ${{ matrix.node-version }}
 
       - name: Install


### PR DESCRIPTION
This PR:

-   Bumps actions to latest major versions
-   Adds Node 18 to test matrix
-   Removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false, they are not used after the initial checkout
- Declares the minimum permissions for CI workflows to run at either the workflow or job level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)
-   Enables `concurrency` in `ci.yml`; see [related docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency), this allows a subsequently queued workflow run to interrupt previous runs in PRs