### PR TITLE
Update validator to remove Node vm dependency

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { createContext, runInContext } = require('vm')
-
 module.exports = validator
 
 function validator (opts = {}) {
@@ -17,19 +15,16 @@ function validator (opts = {}) {
       }
       try {
         if (/〇/.test(s)) throw Error()
-        const proxy = new Proxy({}, { get: () => proxy, set: () => { throw Error() } })
         const expr = (s[0] === '[' ? '' : '.') + s.replace(/^\*/, '〇').replace(/\.\*/g, '.〇').replace(/\[\*\]/g, '[〇]')
         if (/\n|\r|;/.test(expr)) throw Error()
         if (/\/\*/.test(expr)) throw Error()
-        runInContext(`
-          (function () {
+        /* eslint-disable-next-line */
+        Function(`
             'use strict'
+            const o = new Proxy({}, { get: () => o, set: () => { throw Error() } });
+            const 〇 = null;
             o${expr}
-            if ([o${expr}].length !== 1) throw Error()
-          })()
-        `, createContext({ o: proxy, 〇: null }), {
-          codeGeneration: { strings: false, wasm: false }
-        })
+            if ([o${expr}].length !== 1) throw Error()`)()
       } catch (e) {
         throw Error(ERR_INVALID_PATH(s))
       }


### PR DESCRIPTION
Removing `vm` references and replacing the validation code with a Function eval.

This change should enable the use of fast-redact in browsers and Deno.

Addresses issue #37