### PR TITLE
perf: batch validation of paths

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -9,7 +9,8 @@ function validator (opts = {}) {
   } = opts
 
   return function validate ({ paths }) {
-    paths.forEach((s) => {
+    const proxy = new Proxy({}, { get: () => proxy, set: () => { throw Error() } })
+    const exprsToCheck = paths.map((s, i) => {
       if (typeof s !== 'string') {
         throw Error(ERR_PATHS_MUST_BE_STRINGS())
       }
@@ -18,16 +19,33 @@ function validator (opts = {}) {
         const expr = (s[0] === '[' ? '' : '.') + s.replace(/^\*/, '〇').replace(/\.\*/g, '.〇').replace(/\[\*\]/g, '[〇]')
         if (/\n|\r|;/.test(expr)) throw Error()
         if (/\/\*/.test(expr)) throw Error()
-        /* eslint-disable-next-line */
-        Function(`
-            'use strict'
-            const o = new Proxy({}, { get: () => o, set: () => { throw Error() } });
-            const 〇 = null;
-            o${expr}
-            if ([o${expr}].length !== 1) throw Error()`)()
+
+        return `
+        context.〇〇 = \`${s.replace(/`/g, '\\`')}\`
+        o${expr}
+        if ([o${expr}].length !== 1) return;
+        `
       } catch (e) {
         throw Error(ERR_INVALID_PATH(s))
       }
     })
+
+    const o = new Proxy({}, { get: () => o, set: () => { throw Error() } })
+    const context = { 〇〇: paths[0] }
+
+    try {
+      /* eslint-disable-next-line */
+      Function('〇', 'o', 'context', `
+        'use strict'
+
+        ${exprsToCheck.join('\n')}
+
+        context.〇〇 = null;
+      `)(null, o, context)
+
+      if (context.〇〇 !== null) { throw Error(ERR_INVALID_PATH(context.〇〇)) }
+    } catch (e) {
+      throw Error(ERR_INVALID_PATH(context.〇〇))
+    }
   }
 }


### PR DESCRIPTION
Hello o/

I saw the construction of the `fastRedact` is a little bit slow, in my use case, it took 136ms.

Digging a little bit and I found the main problem was with `createContext` that is used inside `validator.js`.

For each path, it calls `createContext` (the most expensive) and then `runInContext`.

To optimize, instead call it once per path, I join all calls in one script and try to avoid throwing errors inside the validation, instead, I just assign the current path that will be validated to a special variable and then read it in the final.

About the optimizations, below the old redact version:

```
Initializing and redacting x 398 ops/sec ±2.01% (85 runs sampled)
Redacting with cached x 2,095,357 ops/sec ±1.39% (88 runs sampled)
```

And with this new way:

```
Initializing and redacting x 1,257 ops/sec ±3.75% (75 runs sampled)
Redacting with cached x 2,103,045 ops/sec ±1.31% (87 runs sampled)
```

<details>
<summary>benchmark.js</summary>

```js
const Benchmark = require('benchmark')
const suite = new Benchmark.Suite()

const options = {
  paths: ['*.authorization', '*.*.authorization', '*.cookie', '*.*.cookie']
};
const cachedRedact = require('./index')(options)

suite
  .add('Initializing and redacting', function () {
    const fastRedact = require('./index')

    fastRedact(options)({ a: 'test' })
  })
  .add('Redacting with cached', function () {
    cachedRedact({ a: 'test' })
  })
  .on('cycle', function (event) {
    console.log(String(event.target))
  })
  .run({ 'async': false })
```

</details>

As you can see above, the new way initializes ~3x faster than the old version.


