### PR TITLE
docs(paths): add a specific call-out for hyphens

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,15 +15,17 @@ const fauxRequest = {
   headers: {
     host: 'http://example.com',
     cookie: `oh oh we don't want this exposed in logs in etc.`,
-    referer: `if we're cool maybe we'll even redact this`
+    referer: `if we're cool maybe we'll even redact this`,
+    // Note: headers often contain hyphens and require bracket notation
+    'X-Forwarded-For': `192.168.0.1`
   }
 }
 const redact = fastRedact({
-  paths: ['headers.cookie', 'headers.referer']
+  paths: ['headers.cookie', 'headers.referer', 'headers["X-Forwarded-For"]']
 })
 
 console.log(redact(fauxRequest))
-// {"headers":{"host":"http://example.com","cookie":"[REDACTED]","referer":"[REDACTED]"}}
+// {"headers":{"host":"http://example.com","cookie":"[REDACTED]","referer":"[REDACTED]","X-Forwarded-For": "[REDACTED]"}}
 ```
 
 ## API


### PR DESCRIPTION
Hey team!

This PR adds a message in the documentation that specifically calls out hyphens. I'm not sure if this is appropriate, but I've had teams come up against https://github.com/pinojs/pino/issues/480 enough times that I figured it would be nice to add here if you're willing.