### PR TITLE
fix(wildcards): remove old secret references

### DIFF
--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -57,7 +57,7 @@ function nestedRestore (instructions) {
 
 function nestedRedact (store, o, path, ns, censor, isCensorFct, censorFctTakesPath) {
   const target = get(o, path)
-  if (target == null) return
+  if (target == null) return {}
   const keys = Object.keys(target)
   const keysLength = keys.length
   for (var i = 0; i < keysLength; i++) {

--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -57,7 +57,7 @@ function nestedRestore (instructions) {
 
 function nestedRedact (store, o, path, ns, censor, isCensorFct, censorFctTakesPath) {
   const target = get(o, path)
-  if (target == null) return {}
+  if (target == null) return
   const keys = Object.keys(target)
   const keysLength = keys.length
   for (var i = 0; i < keysLength; i++) {

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -11,7 +11,6 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct, censorFctTak
       ${strictImpl(strict, serialize)}
     }
     const { censor, secret } = this
-    console.log(this.secret[''])
     ${redactTmpl(secret, isCensorFct, censorFctTakesPath)}
     this.compileRestore()
     ${dynamicRedactTmpl(wcLen > 0, isCensorFct, censorFctTakesPath)}

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -11,6 +11,7 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct, censorFctTak
       ${strictImpl(strict, serialize)}
     }
     const { censor, secret } = this
+    console.log(this.secret[''])
     ${redactTmpl(secret, isCensorFct, censorFctTakesPath)}
     this.compileRestore()
     ${dynamicRedactTmpl(wcLen > 0, isCensorFct, censorFctTakesPath)}
@@ -74,10 +75,15 @@ function dynamicRedactTmpl (hasWildcards, isCensorFct, censorFctTakesPath) {
     {
       const { wildcards, wcLen, groupRedact, nestedRedact } = this
       for (var i = 0; i < wcLen; i++) {
+        const { beforeStr } = wildcards[i]
+        // clean old references
+        secret[beforeStr] = null
+      }
+      for (var i = 0; i < wcLen; i++) {
         const { before, beforeStr, after, nested } = wildcards[i]
         if (nested === true) {
           secret[beforeStr] = secret[beforeStr] || []
-          nestedRedact(secret[beforeStr], o, before, after, censor, ${isCensorFct}, ${censorFctTakesPath})
+          secret[beforeStr] = nestedRedact(secret[beforeStr], o, before, after, censor, ${isCensorFct}, ${censorFctTakesPath})
         } else secret[beforeStr] = groupRedact(o, before, censor, ${isCensorFct}, ${censorFctTakesPath})
       }
     }

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -11,13 +11,20 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct, censorFctTak
       ${strictImpl(strict, serialize)}
     }
     const { censor, secret } = this
-    const originalSecret = {...secret}
+    const originalSecret = {}
+    const secretKeys = Object.keys(secret)
+    for (var i = 0; i < secretKeys.length; i++) {
+      originalSecret[secretKeys[i]] = secret[secretKeys[i]]
+    }
+
     ${redactTmpl(secret, isCensorFct, censorFctTakesPath)}
     this.compileRestore()
     ${dynamicRedactTmpl(wcLen > 0, isCensorFct, censorFctTakesPath)}
     this.secret = originalSecret
     ${resultTmpl(serialize)}
   `).bind(state)
+
+  redact.secret = secret
 
   if (serialize === false) {
     redact.restore = (o) => state.restore(o)

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -79,7 +79,7 @@ function dynamicRedactTmpl (hasWildcards, isCensorFct, censorFctTakesPath) {
         const { before, beforeStr, after, nested } = wildcards[i]
         if (nested === true) {
           secret[beforeStr] = secret[beforeStr] || []
-          secret[beforeStr] = nestedRedact(secret[beforeStr], o, before, after, censor, ${isCensorFct}, ${censorFctTakesPath})
+          nestedRedact(secret[beforeStr], o, before, after, censor, ${isCensorFct}, ${censorFctTakesPath})
         } else secret[beforeStr] = groupRedact(o, before, censor, ${isCensorFct}, ${censorFctTakesPath})
       }
     }

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -11,9 +11,11 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct, censorFctTak
       ${strictImpl(strict, serialize)}
     }
     const { censor, secret } = this
+    const originalSecret = {...secret}
     ${redactTmpl(secret, isCensorFct, censorFctTakesPath)}
     this.compileRestore()
     ${dynamicRedactTmpl(wcLen > 0, isCensorFct, censorFctTakesPath)}
+    this.secret = originalSecret
     ${resultTmpl(serialize)}
   `).bind(state)
 
@@ -73,11 +75,6 @@ function dynamicRedactTmpl (hasWildcards, isCensorFct, censorFctTakesPath) {
   return hasWildcards === true ? `
     {
       const { wildcards, wcLen, groupRedact, nestedRedact } = this
-      for (var i = 0; i < wcLen; i++) {
-        const { beforeStr } = wildcards[i]
-        // clean old references
-        secret[beforeStr] = null
-      }
       for (var i = 0; i < wcLen; i++) {
         const { before, beforeStr, after, nested } = wildcards[i]
         if (nested === true) {

--- a/lib/restorer.js
+++ b/lib/restorer.js
@@ -70,9 +70,11 @@ function restoreTmpl (resetters, paths, hasWildcards) {
     for (var i = len - 1; i >= ${paths.length}; i--) {
       const k = keys[i]
       const o = secret[k]
-      if (o.flat === true) this.groupRestore(o)
-      else this.nestedRestore(o)
-      secret[k] = null
+      if (o) {
+        if (o.flat === true) this.groupRestore(o)
+        else this.nestedRestore(o)
+        secret[k] = null
+      }
     }
   ` : ''
 

--- a/test/index.js
+++ b/test/index.js
@@ -318,6 +318,17 @@ test('masks according to supplied censor function with nested wildcards', ({ end
   end()
 })
 
+test('does not increment secret size', ({ end, is }) => {
+  const redact = fastRedact({ paths: ['*.b'], censor: censorFct, serialize: false })
+  is(redact({ a: { b: '0123456' } }).a.b, 'xxx56')
+  is(redact.secret[''].length, 1)
+  is(redact({ c: { b: '0123456', d: 'pristine' } }).c.b, 'xxx56')
+  is(redact.secret[''].length, 1)
+  is(redact({ c: { b: '0123456', d: 'pristine' } }).c.d, 'pristine')
+  is(redact.secret[''].length, 1)
+  end()
+})
+
 test('masks according to supplied censor-with-path function', ({ end, is }) => {
   const redact = fastRedact({ paths: ['a'], censor: censorWithPath, serialize: false })
   is(redact({ a: '0123456' }).a, 'a xxx56')


### PR DESCRIPTION
fixes https://github.com/davidmarkclements/fast-redact/issues/63
we can remove old wildcard references from secret object by restoring original object to prevent memory leaks, I used same example as in the issue to see that there is not showing an array incrementing its size in each call