### PR TITLE
fix: restore using latest secret state

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function fastRedact (opts = {}) {
 
   const { wildcards, wcLen, secret } = parse({ paths, censor })
 
-  const compileRestore = restorer({ secret, wcLen })
+  const compileRestore = restorer()
   const strict = 'strict' in opts ? opts.strict : true
 
   return redactor({ secret, wcLen, serialize, strict, isCensorFct, censorFctTakesPath }, state({

--- a/lib/redactor.js
+++ b/lib/redactor.js
@@ -24,7 +24,7 @@ function redactor ({ secret, serialize, wcLen, strict, isCensorFct, censorFctTak
     ${resultTmpl(serialize)}
   `).bind(state)
 
-  redact.secret = secret
+  redact.state = state
 
   if (serialize === false) {
     redact.restore = (o) => state.restore(o)

--- a/lib/restorer.js
+++ b/lib/restorer.js
@@ -4,9 +4,13 @@ const { groupRestore, nestedRestore } = require('./modifiers')
 
 module.exports = restorer
 
-function restorer ({ secret, wcLen }) {
+function restorer () {
   return function compileRestore () {
-    if (this.restore) return
+    if (this.restore) {
+      this.restore.state.secret = this.secret
+      return
+    }
+    const { secret, wcLen } = this
     const paths = Object.keys(secret)
     const resetters = resetTmpl(secret, paths)
     const hasWildcards = wcLen > 0
@@ -16,6 +20,7 @@ function restorer ({ secret, wcLen }) {
       'o',
       restoreTmpl(resetters, paths, hasWildcards)
     ).bind(state)
+    this.restore.state = state
   }
 }
 


### PR DESCRIPTION
These changes are fixing the problem with original object being left mutated after restore execution. It was happening after more than one usage of redact function.
Compiled restore function now always pointing to the latest "secret" state.
Fixed test "does not increment secret size". Previously it was always testing the origin "secret" object, not the restored one, so in general generating false positive.
Extended test: "restores multi nested wildcard values" to cover multiple redact-restore executions.