### PR TITLE
test: add failing redact.restore test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1500,3 +1500,43 @@ test('redact multi trailing wildcard', ({ end, is }) => {
   is(o.a.b.c, 'value')
   end()
 })
+
+test('correctly restores keys matching multiple wildcards', ({ end, deepEqual }) => {
+  const redact = fastRedact({
+    paths: ['a[*]', 'a[*].b'],
+    serialize: false
+  })  
+
+  const o = {
+    a: [{ b: 'b' }]
+  }
+
+  redact(o)
+  deepEqual(o.a, ['[REDACTED]'])
+
+  redact.restore(o)
+  deepEqual(o, {
+    a: [{ b: 'b' }]
+  })
+  end()
+})
+
+test('correctly restores keys matching multiple wildcards', ({ end, deepEqual }) => {
+  const redact = fastRedact({
+    paths: ['a[*].b', 'a[*]'],
+    serialize: false
+  })  
+
+  const o = {
+    a: [{ b: 'b' }]
+  }
+
+  redact(o)
+  deepEqual(o.a, ['[REDACTED]'])
+
+  redact.restore(o)
+  deepEqual(o, {
+    a: [{ b: 'b' }]
+  })
+  end()
+})


### PR DESCRIPTION
Add a minimal failing repro of the issue documented in this pino thread:
https://github.com/pinojs/pino/issues/1997#issuecomment-2507712784

The issue seems to affect `redact.restore` with a given order of wildcard redact paths. Eg:
- `['a[*]', 'a[*].b']` restore correctly
- `['a[*].b', 'a[*]']` doesn't restore correctly